### PR TITLE
Document SignPath code signing policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,4 +84,9 @@ jobs:
             "release/latest.yml",
             "release/SHA256SUMS.txt"
           )
-          gh release create "${{ github.ref_name }}" @assets --title "${{ github.ref_name }} · Maglucen Stardew Valley Companion" --generate-notes --latest --verify-tag
+          $policyNote = @"
+          ## Code signing policy
+
+          See the project [Code signing policy](https://github.com/Maglucen-Studio/StardewValleyTool/blob/${{ github.ref_name }}/CODE_SIGNING_POLICY.md) for signature status, scope, roles, and release approval requirements.
+          "@
+          gh release create "${{ github.ref_name }}" @assets --title "${{ github.ref_name }} · Maglucen Stardew Valley Companion" --notes $policyNote --generate-notes --latest --verify-tag

--- a/CODE_SIGNING_POLICY.md
+++ b/CODE_SIGNING_POLICY.md
@@ -1,0 +1,42 @@
+# Code signing policy
+
+Maglucen Stardew Valley Companion is applying for **Free code signing provided by SignPath.io, certificate by SignPath Foundation**. Until that application is accepted and the release workflow is connected to SignPath, published Windows installers remain unsigned and are identified as such in the release notes.
+
+## Scope
+
+Only release artifacts built from this public repository may be submitted for signing. The signed product name must be **Maglucen Stardew Valley Companion**, and the product version must match the version in `package.json` and the corresponding `v<version>` Git tag.
+
+The project does not use its signing entitlement to sign third-party binaries. Open-source dependencies and operating-system components may be included in a release where their licenses permit it, but retain their original publisher and signature state.
+
+## Roles
+
+The project currently has one maintainer, [@maglucen](https://github.com/maglucen), who holds these responsibilities:
+
+- **Author/committer:** may modify project source through the protected repository workflow.
+- **Reviewer:** reviews contributions from people without commit access before they are merged.
+- **Approver:** manually reviews and approves every SignPath production-signing request.
+
+Automated checks do not replace the required human approval of a signing request. If the maintainer list changes, this policy and the corresponding SignPath roles must be updated before a new member can submit or approve signatures.
+
+## Release and approval process
+
+1. Feature and maintenance changes are merged into `development` through pull requests with the required checks passing.
+2. A release pull request promotes the approved state from `development` to protected `main`.
+3. The release version in `package.json` and the `v<version>` tag must agree.
+4. GitHub Actions builds the Windows installer from that public tag on a GitHub-hosted runner.
+5. The unsigned artifact is submitted to SignPath through its GitHub trusted-build integration.
+6. The approver verifies the tag, commit, checks, product name, version, and expected artifact before manually approving the signing request.
+7. Only the signed artifact returned by SignPath is published. The release also contains SHA-256 checksums and build-provenance information.
+
+No signing request may bypass branch protection, the public tagged build, required checks, or manual approval.
+
+## Security
+
+All repository maintainers and SignPath users must use multi-factor authentication. Credentials and API tokens are stored only as encrypted repository or environment secrets and are never committed to source control.
+
+Security vulnerabilities should be reported using the private process in [SECURITY.md](SECURITY.md).
+
+## Privacy
+
+The application processes save data locally and has no telemetry or hosted user account. It contacts GitHub for release checks and downloads only when the user uses the update functionality. Diagnostic information leaves the computer only when the user chooses to include it in a support report. See [PRIVACY.md](PRIVACY.md) for the complete policy.
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   ·
   <a href="PRIVACY.md">Privacy</a>
   ·
+  <a href="CODE_SIGNING_POLICY.md">Code signing policy</a>
+  ·
   <a href="CONTRIBUTING.md">Contribute</a>
 </p>
 
@@ -41,6 +43,8 @@ The setup assistant checks Steam libraries and common GOG and Xbox locations. It
 ### Windows security notice
 
 The installer is currently unsigned, so Microsoft Defender SmartScreen may identify it as an unrecognized application or an unknown publisher. Only download it from this repository's official [Releases](https://github.com/Maglucen-Studio/StardewValleyTool/releases) page.
+
+The project is preparing an application for free open-source signing through SignPath. See the [Code signing policy](CODE_SIGNING_POLICY.md) for its signing scope, roles, and mandatory release approval process. This documentation does not mean that the currently published installer is already signed.
 
 Every release includes `SHA256SUMS.txt`. To verify a downloaded installer in PowerShell, run:
 
@@ -90,7 +94,7 @@ Use [GitHub Issues](https://github.com/Maglucen-Studio/StardewValleyTool/issues)
 
 This is the canonical source, distribution, and support repository for Maglucen Stardew Valley Companion. Stable installers are built from public tagged source by GitHub Actions. The workflow publishes SHA-256 checksums and a build-provenance attestation with each new release.
 
-The source is available under the [MIT License](LICENSE). See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing changes, [SECURITY.md](SECURITY.md) for private vulnerability reports, [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for dependency notices, and [AI_USAGE.md](AI_USAGE.md) for the project's AI-assisted development disclosure.
+The source is available under the [MIT License](LICENSE). See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing changes, [CODE_SIGNING_POLICY.md](CODE_SIGNING_POLICY.md) for release-signing governance, [SECURITY.md](SECURITY.md) for private vulnerability reports, [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for dependency notices, and [AI_USAGE.md](AI_USAGE.md) for the project's AI-assisted development disclosure.
 
 Stardew Valley assets and game assemblies are deliberately absent. Required images and data are extracted locally from each user's legitimate game installation. Continuous integration compiles the optional SMAPI bridge against public API-only reference assemblies.
 


### PR DESCRIPTION
## Summary
- add the SignPath-required code signing policy, roles, privacy link, and manual approval process
- link the policy from the project homepage and Windows security notice
- prepend the policy link to future GitHub release notes

## Verification
- npm run verify:public
- npm run lint
- npm test (61 tests)