### PR TITLE
feat: link in-app changelog to GitHub

### DIFF
--- a/app/changelog.tsx
+++ b/app/changelog.tsx
@@ -17,6 +17,7 @@ type ChangelogRelease = {
 const RELEASE_HEADING = /^##\s+([^\s]+)\s+—\s+(\d{4}-\d{2}-\d{2})\s*$/;
 const SECTION_HEADING = /^###\s+(.+?)\s*$/;
 const LIST_ENTRY = /^-\s+(.+?)\s*$/;
+const GITHUB_CHANGELOG_URL = "https://github.com/Maglucen-Studio/StardewValleyTool/blob/main/CHANGELOG.md";
 
 export function parseChangelog(markdown: string): ChangelogRelease[] {
   const releases: ChangelogRelease[] = [];
@@ -63,7 +64,12 @@ export function ChangelogHistory() {
 
   return (
     <section className="help-changelog" aria-labelledby="help-changelog-title">
-      <h3 id="help-changelog-title">{t("web.home.changelog")}</h3>
+      <div className="help-changelog-heading">
+        <h3 id="help-changelog-title">{t("web.home.changelog")}</h3>
+        <a href={GITHUB_CHANGELOG_URL} target="_blank" rel="noreferrer">
+          {t("web.home.viewChangelogOnGitHub")} <span aria-hidden="true">↗</span>
+        </a>
+      </div>
       <p className="help-changelog-intro">
         {t("web.home.changelogIsAvailableOfflineAndReleaseNotesAreWrittenInEnglish")}
       </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -552,9 +552,24 @@ button {
   margin-top: 15px;
   font: 11px/1.5 Arial, sans-serif;
 }
-.help-changelog > h3,
+.help-changelog-heading,
+.help-changelog-heading h3,
 .help-changelog-intro {
   margin: 0;
+}
+.help-changelog-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+}
+.help-changelog-heading a {
+  color: #466847;
+  font: 700 9px Arial, sans-serif;
+  text-align: right;
+}
+.help-changelog-heading a:hover {
+  color: #8d5018;
 }
 .help-changelog-intro {
   margin-top: 4px;

--- a/locales/en.json
+++ b/locales/en.json
@@ -914,6 +914,7 @@
   "web.home.desktopDiagnosticsAreUnavailableInThisBrowserSession": "Desktop diagnostics are unavailable in this browser session.",
   "web.home.changelog": "Changelog",
   "web.home.changelogIsAvailableOfflineAndReleaseNotesAreWrittenInEnglish": "Available offline. Release notes are written in English.",
+  "web.home.viewChangelogOnGitHub": "View changelog on GitHub",
   "web.home.layers": "Layers",
   "web.home.whatToDisplay": "What to display",
   "web.home.buildingPalette": "Building palette",

--- a/locales/es.json
+++ b/locales/es.json
@@ -914,6 +914,7 @@
   "web.home.desktopDiagnosticsAreUnavailableInThisBrowserSession": "El diagnóstico de escritorio no está disponible en esta sesión del navegador.",
   "web.home.changelog": "Historial de versiones",
   "web.home.changelogIsAvailableOfflineAndReleaseNotesAreWrittenInEnglish": "Disponible sin conexión. Las notas de las versiones están escritas en inglés.",
+  "web.home.viewChangelogOnGitHub": "Ver el changelog en GitHub",
   "web.home.layers": "Capas",
   "web.home.whatToDisplay": "Qué mostrar",
   "web.home.buildingPalette": "Paleta de edificios",

--- a/tests/changelog.test.mjs
+++ b/tests/changelog.test.mjs
@@ -19,6 +19,8 @@ test("the packaged changelog is structured and matches the application version",
   assert.ok(result.releases.length >= 2);
   assert.match(component, /import changelogMarkdown from "\.\.\/CHANGELOG\.md\?raw"/);
   assert.match(component, /parseChangelog\(changelogMarkdown\)/);
+  assert.match(component, /https:\/\/github\.com\/Maglucen-Studio\/StardewValleyTool\/blob\/main\/CHANGELOG\.md/);
+  assert.match(component, /target="_blank" rel="noreferrer"/);
   assert.match(page, /<ChangelogHistory \/>/);
 });
 


### PR DESCRIPTION
## Summary

- adds a localized external link beside the in-app changelog heading
- opens the canonical `CHANGELOG.md` on GitHub using the existing safe external-link handling
- keeps the bundled offline changelog as the primary experience
- adds regression coverage for the exact HTTPS target and safe link attributes

## Validation

- `npm run verify:public`
- `npm run lint`
- `npm test` (74/74 passing)

Follow-up to #24