### PR TITLE
fix: keep dashboard locale synchronized

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -29,6 +29,12 @@ type LocalizationContextValue = LocalizationPayload & {
   number: (value: number) => string;
   date: (value: { year: number; season: string; day: number }) => string;
 };
+type DesktopLocalization = {
+  getLocalization?: () => Promise<LocalizationPayload>;
+  onLocalizationChanged?: (
+    callback: (payload: LocalizationPayload) => void,
+  ) => (() => void) | undefined;
+};
 
 const fallback: LocalizationPayload = {
   language: "en",
@@ -36,6 +42,30 @@ const fallback: LocalizationPayload = {
   messages: english,
   fallbackMessages: english,
 };
+
+function browserLocalization(): LocalizationPayload {
+  return navigator.language.toLowerCase().startsWith("es")
+    ? {
+        language: "es",
+        locale: "es-ES",
+        messages: spanish,
+        fallbackMessages: english,
+      }
+    : fallback;
+}
+
+function isLocalizationPayload(value: unknown): value is LocalizationPayload {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<LocalizationPayload>;
+  return (
+    (candidate.language === "en" || candidate.language === "es") &&
+    typeof candidate.locale === "string" &&
+    Boolean(candidate.messages) &&
+    typeof candidate.messages === "object" &&
+    Boolean(candidate.fallbackMessages) &&
+    typeof candidate.fallbackMessages === "object"
+  );
+}
 
 function translateMessage(
   messages: Messages,
@@ -83,22 +113,43 @@ export function LocalizationProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<LocalizationPayload>(fallback);
 
   useEffect(() => {
+    let active = true;
     const desktop = (window as Window & {
-      stardewDesktop?: { getLocalization?: () => Promise<LocalizationPayload> };
+      stardewDesktop?: DesktopLocalization;
     }).stardewDesktop;
-    if (desktop?.getLocalization) {
-      desktop.getLocalization().then(setState).catch(() => undefined);
-      return;
-    }
-    if (navigator.language.toLowerCase().startsWith("es"))
-      queueMicrotask(() =>
-        setState({
-          language: "es",
-          locale: "es-ES",
-          messages: spanish,
-          fallbackMessages: english,
-        }),
-      );
+    const apply = (payload: unknown) => {
+      if (active && isLocalizationPayload(payload)) setState(payload);
+    };
+    const applyBrowserFallback = () => {
+      if (active) setState(browserLocalization());
+    };
+    const refresh = async () => {
+      if (!desktop?.getLocalization) {
+        applyBrowserFallback();
+        return;
+      }
+      try {
+        const payload = await desktop.getLocalization();
+        if (isLocalizationPayload(payload)) apply(payload);
+        else applyBrowserFallback();
+      } catch {
+        applyBrowserFallback();
+      }
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+
+    void refresh();
+    const unsubscribe = desktop?.onLocalizationChanged?.(apply);
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      active = false;
+      unsubscribe?.();
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
   }, []);
 
   useEffect(() => {

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -157,6 +157,22 @@ function localizationCatalog(language) {
   return readJson(join(root, "locales", `${language}.json`), {});
 }
 
+function localizationPayload(config = readConfig() || {}) {
+  const state = localizationState(config);
+  return {
+    ...state,
+    messages: localizationCatalog(state.language),
+    fallbackMessages: localizationCatalog("en"),
+  };
+}
+
+function publishLocalizationState(config = readConfig() || {}) {
+  const payload = localizationPayload(config);
+  if (mainWindow && !mainWindow.isDestroyed())
+    mainWindow.webContents.send("localization:changed", payload);
+  return payload;
+}
+
 function desktopTranslator(config = readConfig() || {}) {
   const state = localizationState(config);
   return createTranslator(
@@ -1267,12 +1283,7 @@ function installIpc() {
   });
   ipcMain.handle("localization:get-state", (event) => {
     requireDashboardSender(event);
-    const state = localizationState();
-    return {
-      ...state,
-      messages: localizationCatalog(state.language),
-      fallbackMessages: localizationCatalog("en"),
-    };
+    return localizationPayload();
   });
   ipcMain.handle("display:set-scale", (event, incomingScale) => {
     requireDashboardSender(event);
@@ -1446,6 +1457,7 @@ function installIpc() {
     if (!validConfig(config)) throw new Error(desktopTranslator(config)("setup.invalid"));
     mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+    publishLocalizationState(config);
     Menu.setApplicationMenu(createApplicationMenu());
     if (tray) {
       tray.destroy();

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -3,6 +3,11 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("stardewDesktop", {
   getLocalization: () => ipcRenderer.invoke("localization:get-state"),
+  onLocalizationChanged: callback => {
+    const listener = (_event, state) => callback(state);
+    ipcRenderer.on("localization:changed", listener);
+    return () => ipcRenderer.removeListener("localization:changed", listener);
+  },
   getUpdateState: () => ipcRenderer.invoke("updates:get-state"),
   checkForUpdates: () => ipcRenderer.invoke("updates:check"),
   downloadUpdate: () => ipcRenderer.invoke("updates:download"),

--- a/tests/localization.test.mjs
+++ b/tests/localization.test.mjs
@@ -101,3 +101,22 @@ test("semantic daily and fishing messages are available in both catalogs", () =>
   assert.equal(es("gameName.largeEggBrown", { item: "Huevo XXL" }), "Huevo XXL (marrón)");
   assert.match(es("today.brief.caveCollectibles", { count: 2, cave: "murciélagos fruteros" }), /2 objetos/);
 });
+
+test("desktop and renderer keep the Companion locale synchronized", async () => {
+  const [provider, preload, desktop] = await Promise.all([
+    readFile(new URL("../app/i18n.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../desktop/preload.cjs", import.meta.url), "utf8"),
+    readFile(new URL("../desktop/main.mjs", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(preload, /onLocalizationChanged: callback =>/);
+  assert.match(preload, /ipcRenderer\.on\("localization:changed", listener\)/);
+  assert.match(desktop, /function localizationPayload\(config = readConfig\(\) \|\| \{\}\)/);
+  assert.match(desktop, /mainWindow\.webContents\.send\("localization:changed", payload\)/);
+  assert.match(desktop, /writeFileSync\(configPath,[\s\S]*publishLocalizationState\(config\)/);
+  assert.match(provider, /desktop\?\.onLocalizationChanged\?\.\(apply\)/);
+  assert.match(provider, /window\.addEventListener\("focus", refresh\)/);
+  assert.match(provider, /document\.addEventListener\("visibilitychange", handleVisibility\)/);
+  assert.match(provider, /catch \{\s*applyBrowserFallback\(\);\s*\}/);
+  assert.doesNotMatch(provider, /getLocalization\(\)\.then\(setState\)\.catch\(\(\) => undefined\)/);
+});


### PR DESCRIPTION
## Summary
- synchronize the React dashboard locale with the language saved by the Electron settings window
- publish language changes immediately through the preload bridge
- refresh locale state on focus/visibility and use the renderer language only as a safe fallback
- add a regression test for the desktop-to-renderer localization contract

## Validation
- npm run verify:public
- npm run lint
- npm test (75 tests)
- manual end-to-end switch: Spanish -> English -> Spanish without restarting

Refs #27