### PR TITLE
fix: anchor farmhouse decorations to their saved footprint

### DIFF
--- a/app/furniture-layout.mjs
+++ b/app/furniture-layout.mjs
@@ -1,0 +1,29 @@
+const SOURCE_TILE_SIZE = 16;
+
+/**
+ * Match Stardew Valley's furniture anchoring: tileLocation is the top-left of
+ * the collision footprint, while the sprite is anchored to its bottom edge.
+ *
+ * @param {{
+ *   x: number,
+ *   y: number,
+ *   sourceWidth?: number,
+ *   sourceHeight?: number,
+ *   footprintHeight?: number,
+ * }} item
+ * @param {number} [tileSize]
+ * @returns {[number, number, number, number]}
+ */
+export function furnitureDestination(item, tileSize = SOURCE_TILE_SIZE) {
+  const sourceWidth = Math.max(0, Number(item.sourceWidth) || 0);
+  const sourceHeight = Math.max(0, Number(item.sourceHeight) || 0);
+  const footprintHeight = Math.max(1, Number(item.footprintHeight) || 1);
+  const scale = tileSize / SOURCE_TILE_SIZE;
+
+  return [
+    item.x * tileSize,
+    (item.y + footprintHeight) * tileSize - sourceHeight * scale,
+    sourceWidth * scale,
+    sourceHeight * scale,
+  ];
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import packageMetadata from "../package.json";
 import { ChangelogHistory } from "./changelog";
+import { furnitureDestination } from "./furniture-layout.mjs";
 import { useI18n, type MessageDescriptor } from "./i18n";
 
 const APPLICATION_VERSION = packageMetadata.version;
@@ -67,6 +68,7 @@ type Interior = {
     sourceY?: number;
     sourceWidth?: number;
     sourceHeight?: number;
+    footprintHeight?: number;
   })[];
 };
 type Suggestion = Building & { id: string; kind: string; color: string };
@@ -4751,8 +4753,7 @@ function InteriorView({
         entity.sourceHeight &&
         sprites.furniture
       ) {
-        const width = entity.sourceWidth * 2,
-          height = entity.sourceHeight * 2;
+        const destination = furnitureDestination(entity, size);
         sprite(
           ctx,
           sprites.furniture,
@@ -4762,7 +4763,7 @@ function InteriorView({
             entity.sourceWidth,
             entity.sourceHeight,
           ],
-          [px, py - Math.max(0, height - size), width, height],
+          destination,
         );
       } else {
         ctx.fillStyle = "#9a7048";
@@ -5394,10 +5395,13 @@ function StorageLocationPreviewCanvas({
       }
       if (entity.type === "furniture") {
         const item = entity.item;
-        const px = item.x * TILE;
-        const py = item.y * TILE;
         if (item.sourceWidth && item.sourceHeight && sprites.furniture)
-          sprite(ctx, sprites.furniture, [item.sourceX || 0, item.sourceY || 0, item.sourceWidth, item.sourceHeight], [px, py - Math.max(0, item.sourceHeight - TILE)]);
+          sprite(
+            ctx,
+            sprites.furniture,
+            [item.sourceX || 0, item.sourceY || 0, item.sourceWidth, item.sourceHeight],
+            furnitureDestination(item, TILE),
+          );
         continue;
       }
       const item = entity.item;

--- a/scripts/generate_snapshot.py
+++ b/scripts/generate_snapshot.py
@@ -679,10 +679,15 @@ def interior_views(locations: ET.Element, player: ET.Element, farm: ET.Element) 
             if pos is None:
                 continue
             source = item.find("sourceRect")
+            bounding = item.find("boundingBox")
+            footprint_height = 1
+            if bounding is not None:
+                footprint_height = max(1, (number(bounding, "Height", 64) + 63) // 64)
             furniture.append({
                 "x": number(pos, "X"), "y": number(pos, "Y"), "name": item.findtext("name", "Furniture"),
                 "sourceX": number(source, "X"), "sourceY": number(source, "Y"),
                 "sourceWidth": number(source, "Width"), "sourceHeight": number(source, "Height"),
+                "footprintHeight": footprint_height,
             })
         max_x = max([item["x"] for item in objects + furniture] + [9])
         max_y = max([item["y"] for item in objects + furniture] + [9])

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile as readRawFile } from "node:fs/promises";
 import test from "node:test";
+import { furnitureDestination } from "../app/furniture-layout.mjs";
 
 async function readFile(path, encoding) {
   const source = await readRawFile(path, encoding);
@@ -38,6 +39,48 @@ test("server renders the local Maglucen companion shell", async () => {
   );
   assert.match(html, /Preparing your farm/);
   assert.doesNotMatch(html, /codex-preview|Your site is taking shape/i);
+});
+
+test("furniture sprites anchor to the bottom of their saved collision footprint", async () => {
+  assert.deepEqual(
+    furnitureDestination({
+      x: 4,
+      y: 4,
+      sourceWidth: 16,
+      sourceHeight: 32,
+      footprintHeight: 1,
+    }),
+    [64, 48, 16, 32],
+  );
+  assert.deepEqual(
+    furnitureDestination({
+      x: 5,
+      y: 4,
+      sourceWidth: 32,
+      sourceHeight: 48,
+      footprintHeight: 2,
+    }),
+    [80, 48, 32, 48],
+  );
+  assert.deepEqual(
+    furnitureDestination({
+      x: 7,
+      y: 8,
+      sourceWidth: 32,
+      sourceHeight: 48,
+      footprintHeight: 3,
+    }),
+    [112, 128, 32, 48],
+  );
+
+  const [generator, page] = await Promise.all([
+    readRawFile(new URL("../scripts/generate_snapshot.py", import.meta.url), "utf8"),
+    readRawFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+  ]);
+  assert.match(generator, /item\.find\("boundingBox"\)/);
+  assert.match(generator, /"footprintHeight": footprint_height/);
+  assert.match(page, /furnitureDestination\(entity, size\)/);
+  assert.match(page, /furnitureDestination\(item, TILE\)/);
 });
 
 test("the localization context interpolates variables before and after desktop hydration", async () => {


### PR DESCRIPTION
## Cause
Stardew's 	ileLocation is the top-left of a furniture collision footprint. The renderer treated every footprint as one tile and anchored the sprite there, so furniture with a two-tile footprint appeared one tile too high and three-tile furniture could appear two tiles too high.

## Fix
- read the furniture oundingBox height from the save copy
- convert it into a collision-footprint height
- anchor furniture sprites to the bottom of that footprint in both interior renderers
- retain the previous position for one-tile furniture and legacy snapshots
- cover one-, two-, and three-tile furniture with a behavioral regression test

## Validation
- npm run verify:public
- npm run lint
- npm test (76 passing)
- verified local save examples: chair/plant (1 tile), table/TV/windows (2 tiles), bed/rug (3 tiles)

Refs #22