### PR TITLE
fix: preserve Stardew foreground occlusion in interior maps

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7674,6 +7674,13 @@ button {
   height: 100%;
   image-rendering: pixelated;
 }
+.storage-location-preview-foreground {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  image-rendering: pixelated;
+}
 .storage-container-groups h3 {
   margin: 0;
   font: 700 18px Georgia, serif;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,6 +61,7 @@ type Interior = {
   width: number;
   height: number;
   background?: string;
+  foreground?: string;
   objects: FarmObject[];
   furniture: (Tile & {
     name: string;
@@ -110,7 +111,7 @@ type Snapshot = {
   interiors: Interior[];
   locationMaps?: Record<
     string,
-    { background: string; width: number; height: number }
+    { background: string; foreground?: string; width: number; height: number }
   >;
   suggestions: Suggestion[];
 };
@@ -4656,6 +4657,10 @@ function InteriorView({
     path: string;
     image: HTMLImageElement;
   } | null>(null);
+  const [foreground, setForeground] = useState<{
+    path: string;
+    image: HTMLImageElement;
+  } | null>(null);
   const size = 32;
 
   useEffect(() => {
@@ -4665,6 +4670,14 @@ function InteriorView({
     image.onload = () => setBackground({ path, image });
     image.src = path;
   }, [interior.background]);
+
+  useEffect(() => {
+    if (!interior.foreground) return;
+    const path = interior.foreground;
+    const image = new Image();
+    image.onload = () => setForeground({ path, image });
+    image.src = path;
+  }, [interior.foreground]);
 
   useEffect(() => {
     const element = canvas.current;
@@ -4783,6 +4796,11 @@ function InteriorView({
       }
     }
 
+    const currentForeground = foreground;
+    if (currentForeground && currentForeground.path === interior.foreground) {
+      ctx.drawImage(currentForeground.image, 0, 0, element.width, element.height);
+    }
+
     if (showGrid) {
       ctx.strokeStyle = "rgba(58,39,25,.28)";
       ctx.lineWidth = 1;
@@ -4811,6 +4829,7 @@ function InteriorView({
     }
   }, [
     background,
+    foreground,
     interior,
     selected,
     showGrid,
@@ -5277,6 +5296,9 @@ function StorageLocationPreviewCanvas({
   const background = normalizedLocation === "Farm"
     ? current.locationMaps?.Farm?.background
     : interior?.background || extractedLocation?.background;
+  const foreground = normalizedLocation === "Farm"
+    ? undefined
+    : interior?.foreground || extractedLocation?.foreground;
   const mapWidth = normalizedLocation === "Farm"
     ? current.map.width
     : interior?.width || extractedLocation?.width;
@@ -5452,6 +5474,16 @@ function StorageLocationPreviewCanvas({
       aria-hidden="true"
     >
       <canvas ref={canvas} width={frameWidth * TILE} height={frameHeight * TILE} />
+      {foreground ? (
+        <span
+          className="storage-location-preview-foreground"
+          style={{
+            backgroundImage: `url("${foreground}")`,
+            backgroundSize: `${mapWidth * 12}px ${mapHeight * 12}px`,
+            backgroundPosition: `${-startX * 12}px ${-startY * 12}px`,
+          }}
+        />
+      ) : null}
     </span>
   );
 }

--- a/scripts/render-community-rooms.mjs
+++ b/scripts/render-community-rooms.mjs
@@ -127,7 +127,11 @@ function blendPixel(target, targetOffset, source, sourceOffset) {
   target[targetOffset + 3] = Math.round(outputAlpha * 255);
 }
 
-export async function renderMap(mapPath, sheetPaths) {
+export function isForegroundMapLayer(layerId) {
+  return /^(?:Front|AlwaysFront)/i.test(String(layerId || ""));
+}
+
+export async function renderMap(mapPath, sheetPaths, { layerFilter = () => true } = {}) {
   const map = readMap(await readFile(mapPath));
   const firstLayer = map.layers[0];
   const output = new PNG({ width: firstLayer.size.width * 16, height: firstLayer.size.height * 16 });
@@ -137,7 +141,7 @@ export async function renderMap(mapPath, sheetPaths) {
     if (path) images.set(sheet.id, PNG.sync.read(await readFile(path)));
   }
   for (const layer of map.layers) {
-    if (!layer.visible || layer.id === "Paths") continue;
+    if (!layer.visible || layer.id === "Paths" || !layerFilter(layer)) continue;
     for (let y = 0; y < layer.size.height; y += 1) for (let x = 0; x < layer.size.width; x += 1) {
       const tile = layer.tiles[y * layer.size.width + x];
       const sheet = tile && map.sheets.get(tile.sheetId);

--- a/scripts/render-storage-location-maps.mjs
+++ b/scripts/render-storage-location-maps.mjs
@@ -4,7 +4,12 @@ import { basename, dirname, resolve } from "node:path";
 import { PNG } from "pngjs";
 import { unpackToFiles } from "xnb";
 import { loadConfig, runtimeRoot, runtimePaths } from "./config.mjs";
-import { blockedMapTiles, readMap, renderMap } from "./render-community-rooms.mjs";
+import {
+  blockedMapTiles,
+  isForegroundMapLayer,
+  readMap,
+  renderMap,
+} from "./render-community-rooms.mjs";
 
 const config = loadConfig();
 const { contentRoot } = runtimePaths(config);
@@ -74,7 +79,11 @@ async function cachedTexture(source, imageSource, season) {
   return destination;
 }
 
-async function renderLocation(mapName, season, { includeBlocked = false } = {}) {
+async function renderLocation(
+  mapName,
+  season,
+  { includeBlocked = false, layered = false } = {},
+) {
   const source = mapPathFor(mapName);
   if (!source) return null;
   const tbinPath = resolve(cacheRoot, "maps", `${safeName(mapName)}.tbin`);
@@ -95,7 +104,8 @@ async function renderLocation(mapName, season, { includeBlocked = false } = {}) 
         season,
       );
   }
-  const fileName = `${safeName(mapName)}-${safeName(season)}.png`;
+  const fileStem = `${safeName(mapName)}-${safeName(season)}`;
+  const fileName = `${fileStem}${layered ? "-base" : ""}.png`;
   const destination = resolve(publicRoot, fileName);
   const destinationTime = existsSync(destination) ? (await stat(destination)).mtimeMs : 0;
   const newestInput = Math.max(
@@ -104,12 +114,38 @@ async function renderLocation(mapName, season, { includeBlocked = false } = {}) 
   );
   if (destinationTime < newestInput) {
     await mkdir(publicRoot, { recursive: true });
-    const image = await renderMap(tbinPath, sheets);
+    const image = await renderMap(tbinPath, sheets, {
+      layerFilter: layered
+        ? (layer) => !isForegroundMapLayer(layer.id)
+        : () => true,
+    });
     await writeFile(destination, PNG.sync.write(image));
+  }
+  const hasForeground = layered && map.layers.some(
+    (layer) => layer.visible
+      && isForegroundMapLayer(layer.id)
+      && layer.tiles.some(Boolean),
+  );
+  let foreground;
+  if (hasForeground) {
+    const foregroundFileName = `${fileStem}-foreground.png`;
+    const foregroundDestination = resolve(publicRoot, foregroundFileName);
+    const foregroundTime = existsSync(foregroundDestination)
+      ? (await stat(foregroundDestination)).mtimeMs
+      : 0;
+    if (foregroundTime < newestInput) {
+      await mkdir(publicRoot, { recursive: true });
+      const image = await renderMap(tbinPath, sheets, {
+        layerFilter: (layer) => isForegroundMapLayer(layer.id),
+      });
+      await writeFile(foregroundDestination, PNG.sync.write(image));
+    }
+    foreground = `/assets/location-maps/${foregroundFileName}`;
   }
   const firstLayer = map.layers[0];
   return {
     background: `/assets/location-maps/${fileName}`,
+    ...(foreground ? { foreground } : {}),
     width: firstLayer.size.width,
     height: firstLayer.size.height,
     ...(includeBlocked ? { blocked: blockedMapTiles(map) } : {}),
@@ -147,7 +183,7 @@ const farmMapNames = {
 
 function interiorMapName(interior) {
   if (interior.mapName) return interior.mapName;
-  const contextualName = /\/location-maps\/([^/]+)-(?:spring|summer|fall|winter)\.png$/i
+  const contextualName = /\/location-maps\/([^/]+)-(?:spring|summer|fall|winter)(?:-(?:base|foreground))?\.png$/i
     .exec(interior.background || "")?.[1];
   if (contextualName) return contextualName;
   const fileName = /\/([^/]+)\.png$/i.exec(interior.background || "")?.[1];
@@ -215,10 +251,11 @@ async function main() {
     const mapName = interiorMapName(interior);
     if (!mapName) continue;
     try {
-      const rendered = await renderLocation(mapName, season);
+      const rendered = await renderLocation(mapName, season, { layered: true });
       if (!rendered) continue;
       locationMaps[interior.id] = rendered;
       interior.background = rendered.background;
+      interior.foreground = rendered.foreground;
       interior.width = rendered.width;
       interior.height = rendered.height;
     } catch (error) {

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFile as readRawFile } from "node:fs/promises";
 import test from "node:test";
 import { furnitureDestination } from "../app/furniture-layout.mjs";
+import { isForegroundMapLayer } from "../scripts/render-community-rooms.mjs";
 
 async function readFile(path, encoding) {
   const source = await readRawFile(path, encoding);
@@ -81,6 +82,25 @@ test("furniture sprites anchor to the bottom of their saved collision footprint"
   assert.match(generator, /"footprintHeight": footprint_height/);
   assert.match(page, /furnitureDestination\(entity, size\)/);
   assert.match(page, /furnitureDestination\(item, TILE\)/);
+});
+
+test("interior foreground map layers occlude furniture like Stardew Valley", async () => {
+  assert.equal(isForegroundMapLayer("Back"), false);
+  assert.equal(isForegroundMapLayer("Buildings"), false);
+  assert.equal(isForegroundMapLayer("Front"), true);
+  assert.equal(isForegroundMapLayer("Front2"), true);
+  assert.equal(isForegroundMapLayer("AlwaysFront"), true);
+
+  const [renderer, page, styles] = await Promise.all([
+    readRawFile(new URL("../scripts/render-storage-location-maps.mjs", import.meta.url), "utf8"),
+    readRawFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+    readRawFile(new URL("../app/globals.css", import.meta.url), "utf8"),
+  ]);
+  assert.match(renderer, /renderLocation\(mapName, season, \{ layered: true \}\)/);
+  assert.match(renderer, /interior\.foreground = rendered\.foreground/);
+  assert.match(page, /ctx\.drawImage\(currentForeground\.image/);
+  assert.match(page, /storage-location-preview-foreground/);
+  assert.match(styles, /\.storage-location-preview-foreground/);
 });
 
 test("the localization context interpolates variables before and after desktop hydration", async () => {
@@ -1266,7 +1286,7 @@ test("physical chests can request locally rendered maps for any game location", 
   assert.match(renderer, /snapshot\.planningBrief\?\.inventory/);
   assert.match(renderer, /resolve\(contentRoot, "Maps", `\$\{name\}\.xnb`\)/);
   assert.match(renderer, /seasonalSheetName\(imageSource, season\)/);
-  assert.match(renderer, /await renderMap\(tbinPath, sheets\)/);
+  assert.match(renderer, /await renderMap\(tbinPath, sheets,/);
   assert.match(renderer, /snapshot\.locationMaps = locationMaps/);
   assert.match(renderer, /liveState\.storage \|\| \[\]/);
   assert.match(renderer, /1: "Farm_Fishing"/);


### PR DESCRIPTION
## Cause
The local map renderer flattened Back, Buildings, and Front into one image. Companion then drew furniture above that flattened image, so foreground walls could not occlude furniture as they do in Stardew Valley.

## Fix
- render interior maps into a base layer and a transparent foreground layer
- draw furniture and objects between those layers in both interior views
- recognize Front, numbered Front layers, and AlwaysFront as foreground
- keep farm/world rendering unchanged
- retain map selection by save-provided mapName and current season

## Validation
- npm run verify:public
- npm run lint
- npm test (77 passing)
- local FarmHouse render verified with Back/Buildings base plus transparent Front border

Refs #22