### PR TITLE
release: promote interior rendering fixes

### DIFF
--- a/app/furniture-layout.mjs
+++ b/app/furniture-layout.mjs
@@ -1,0 +1,29 @@
+const SOURCE_TILE_SIZE = 16;
+
+/**
+ * Match Stardew Valley's furniture anchoring: tileLocation is the top-left of
+ * the collision footprint, while the sprite is anchored to its bottom edge.
+ *
+ * @param {{
+ *   x: number,
+ *   y: number,
+ *   sourceWidth?: number,
+ *   sourceHeight?: number,
+ *   footprintHeight?: number,
+ * }} item
+ * @param {number} [tileSize]
+ * @returns {[number, number, number, number]}
+ */
+export function furnitureDestination(item, tileSize = SOURCE_TILE_SIZE) {
+  const sourceWidth = Math.max(0, Number(item.sourceWidth) || 0);
+  const sourceHeight = Math.max(0, Number(item.sourceHeight) || 0);
+  const footprintHeight = Math.max(1, Number(item.footprintHeight) || 1);
+  const scale = tileSize / SOURCE_TILE_SIZE;
+
+  return [
+    item.x * tileSize,
+    (item.y + footprintHeight) * tileSize - sourceHeight * scale,
+    sourceWidth * scale,
+    sourceHeight * scale,
+  ];
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7674,6 +7674,13 @@ button {
   height: 100%;
   image-rendering: pixelated;
 }
+.storage-location-preview-foreground {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  image-rendering: pixelated;
+}
 .storage-container-groups h3 {
   margin: 0;
   font: 700 18px Georgia, serif;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import packageMetadata from "../package.json";
 import { ChangelogHistory } from "./changelog";
+import { furnitureDestination } from "./furniture-layout.mjs";
 import { useI18n, type MessageDescriptor } from "./i18n";
 
 const APPLICATION_VERSION = packageMetadata.version;
@@ -60,6 +61,7 @@ type Interior = {
   width: number;
   height: number;
   background?: string;
+  foreground?: string;
   objects: FarmObject[];
   furniture: (Tile & {
     name: string;
@@ -67,6 +69,7 @@ type Interior = {
     sourceY?: number;
     sourceWidth?: number;
     sourceHeight?: number;
+    footprintHeight?: number;
   })[];
 };
 type Suggestion = Building & { id: string; kind: string; color: string };
@@ -108,7 +111,7 @@ type Snapshot = {
   interiors: Interior[];
   locationMaps?: Record<
     string,
-    { background: string; width: number; height: number }
+    { background: string; foreground?: string; width: number; height: number }
   >;
   suggestions: Suggestion[];
 };
@@ -4654,6 +4657,10 @@ function InteriorView({
     path: string;
     image: HTMLImageElement;
   } | null>(null);
+  const [foreground, setForeground] = useState<{
+    path: string;
+    image: HTMLImageElement;
+  } | null>(null);
   const size = 32;
 
   useEffect(() => {
@@ -4663,6 +4670,14 @@ function InteriorView({
     image.onload = () => setBackground({ path, image });
     image.src = path;
   }, [interior.background]);
+
+  useEffect(() => {
+    if (!interior.foreground) return;
+    const path = interior.foreground;
+    const image = new Image();
+    image.onload = () => setForeground({ path, image });
+    image.src = path;
+  }, [interior.foreground]);
 
   useEffect(() => {
     const element = canvas.current;
@@ -4751,8 +4766,7 @@ function InteriorView({
         entity.sourceHeight &&
         sprites.furniture
       ) {
-        const width = entity.sourceWidth * 2,
-          height = entity.sourceHeight * 2;
+        const destination = furnitureDestination(entity, size);
         sprite(
           ctx,
           sprites.furniture,
@@ -4762,7 +4776,7 @@ function InteriorView({
             entity.sourceWidth,
             entity.sourceHeight,
           ],
-          [px, py - Math.max(0, height - size), width, height],
+          destination,
         );
       } else {
         ctx.fillStyle = "#9a7048";
@@ -4780,6 +4794,11 @@ function InteriorView({
           py + size / 2,
         );
       }
+    }
+
+    const currentForeground = foreground;
+    if (currentForeground && currentForeground.path === interior.foreground) {
+      ctx.drawImage(currentForeground.image, 0, 0, element.width, element.height);
     }
 
     if (showGrid) {
@@ -4810,6 +4829,7 @@ function InteriorView({
     }
   }, [
     background,
+    foreground,
     interior,
     selected,
     showGrid,
@@ -5276,6 +5296,9 @@ function StorageLocationPreviewCanvas({
   const background = normalizedLocation === "Farm"
     ? current.locationMaps?.Farm?.background
     : interior?.background || extractedLocation?.background;
+  const foreground = normalizedLocation === "Farm"
+    ? undefined
+    : interior?.foreground || extractedLocation?.foreground;
   const mapWidth = normalizedLocation === "Farm"
     ? current.map.width
     : interior?.width || extractedLocation?.width;
@@ -5394,10 +5417,13 @@ function StorageLocationPreviewCanvas({
       }
       if (entity.type === "furniture") {
         const item = entity.item;
-        const px = item.x * TILE;
-        const py = item.y * TILE;
         if (item.sourceWidth && item.sourceHeight && sprites.furniture)
-          sprite(ctx, sprites.furniture, [item.sourceX || 0, item.sourceY || 0, item.sourceWidth, item.sourceHeight], [px, py - Math.max(0, item.sourceHeight - TILE)]);
+          sprite(
+            ctx,
+            sprites.furniture,
+            [item.sourceX || 0, item.sourceY || 0, item.sourceWidth, item.sourceHeight],
+            furnitureDestination(item, TILE),
+          );
         continue;
       }
       const item = entity.item;
@@ -5448,6 +5474,16 @@ function StorageLocationPreviewCanvas({
       aria-hidden="true"
     >
       <canvas ref={canvas} width={frameWidth * TILE} height={frameHeight * TILE} />
+      {foreground ? (
+        <span
+          className="storage-location-preview-foreground"
+          style={{
+            backgroundImage: `url("${foreground}")`,
+            backgroundSize: `${mapWidth * 12}px ${mapHeight * 12}px`,
+            backgroundPosition: `${-startX * 12}px ${-startY * 12}px`,
+          }}
+        />
+      ) : null}
     </span>
   );
 }

--- a/scripts/generate_snapshot.py
+++ b/scripts/generate_snapshot.py
@@ -679,10 +679,15 @@ def interior_views(locations: ET.Element, player: ET.Element, farm: ET.Element) 
             if pos is None:
                 continue
             source = item.find("sourceRect")
+            bounding = item.find("boundingBox")
+            footprint_height = 1
+            if bounding is not None:
+                footprint_height = max(1, (number(bounding, "Height", 64) + 63) // 64)
             furniture.append({
                 "x": number(pos, "X"), "y": number(pos, "Y"), "name": item.findtext("name", "Furniture"),
                 "sourceX": number(source, "X"), "sourceY": number(source, "Y"),
                 "sourceWidth": number(source, "Width"), "sourceHeight": number(source, "Height"),
+                "footprintHeight": footprint_height,
             })
         max_x = max([item["x"] for item in objects + furniture] + [9])
         max_y = max([item["y"] for item in objects + furniture] + [9])

--- a/scripts/render-community-rooms.mjs
+++ b/scripts/render-community-rooms.mjs
@@ -127,7 +127,11 @@ function blendPixel(target, targetOffset, source, sourceOffset) {
   target[targetOffset + 3] = Math.round(outputAlpha * 255);
 }
 
-export async function renderMap(mapPath, sheetPaths) {
+export function isForegroundMapLayer(layerId) {
+  return /^(?:Front|AlwaysFront)/i.test(String(layerId || ""));
+}
+
+export async function renderMap(mapPath, sheetPaths, { layerFilter = () => true } = {}) {
   const map = readMap(await readFile(mapPath));
   const firstLayer = map.layers[0];
   const output = new PNG({ width: firstLayer.size.width * 16, height: firstLayer.size.height * 16 });
@@ -137,7 +141,7 @@ export async function renderMap(mapPath, sheetPaths) {
     if (path) images.set(sheet.id, PNG.sync.read(await readFile(path)));
   }
   for (const layer of map.layers) {
-    if (!layer.visible || layer.id === "Paths") continue;
+    if (!layer.visible || layer.id === "Paths" || !layerFilter(layer)) continue;
     for (let y = 0; y < layer.size.height; y += 1) for (let x = 0; x < layer.size.width; x += 1) {
       const tile = layer.tiles[y * layer.size.width + x];
       const sheet = tile && map.sheets.get(tile.sheetId);

--- a/scripts/render-storage-location-maps.mjs
+++ b/scripts/render-storage-location-maps.mjs
@@ -4,7 +4,12 @@ import { basename, dirname, resolve } from "node:path";
 import { PNG } from "pngjs";
 import { unpackToFiles } from "xnb";
 import { loadConfig, runtimeRoot, runtimePaths } from "./config.mjs";
-import { blockedMapTiles, readMap, renderMap } from "./render-community-rooms.mjs";
+import {
+  blockedMapTiles,
+  isForegroundMapLayer,
+  readMap,
+  renderMap,
+} from "./render-community-rooms.mjs";
 
 const config = loadConfig();
 const { contentRoot } = runtimePaths(config);
@@ -74,7 +79,11 @@ async function cachedTexture(source, imageSource, season) {
   return destination;
 }
 
-async function renderLocation(mapName, season, { includeBlocked = false } = {}) {
+async function renderLocation(
+  mapName,
+  season,
+  { includeBlocked = false, layered = false } = {},
+) {
   const source = mapPathFor(mapName);
   if (!source) return null;
   const tbinPath = resolve(cacheRoot, "maps", `${safeName(mapName)}.tbin`);
@@ -95,7 +104,8 @@ async function renderLocation(mapName, season, { includeBlocked = false } = {}) 
         season,
       );
   }
-  const fileName = `${safeName(mapName)}-${safeName(season)}.png`;
+  const fileStem = `${safeName(mapName)}-${safeName(season)}`;
+  const fileName = `${fileStem}${layered ? "-base" : ""}.png`;
   const destination = resolve(publicRoot, fileName);
   const destinationTime = existsSync(destination) ? (await stat(destination)).mtimeMs : 0;
   const newestInput = Math.max(
@@ -104,12 +114,38 @@ async function renderLocation(mapName, season, { includeBlocked = false } = {}) 
   );
   if (destinationTime < newestInput) {
     await mkdir(publicRoot, { recursive: true });
-    const image = await renderMap(tbinPath, sheets);
+    const image = await renderMap(tbinPath, sheets, {
+      layerFilter: layered
+        ? (layer) => !isForegroundMapLayer(layer.id)
+        : () => true,
+    });
     await writeFile(destination, PNG.sync.write(image));
+  }
+  const hasForeground = layered && map.layers.some(
+    (layer) => layer.visible
+      && isForegroundMapLayer(layer.id)
+      && layer.tiles.some(Boolean),
+  );
+  let foreground;
+  if (hasForeground) {
+    const foregroundFileName = `${fileStem}-foreground.png`;
+    const foregroundDestination = resolve(publicRoot, foregroundFileName);
+    const foregroundTime = existsSync(foregroundDestination)
+      ? (await stat(foregroundDestination)).mtimeMs
+      : 0;
+    if (foregroundTime < newestInput) {
+      await mkdir(publicRoot, { recursive: true });
+      const image = await renderMap(tbinPath, sheets, {
+        layerFilter: (layer) => isForegroundMapLayer(layer.id),
+      });
+      await writeFile(foregroundDestination, PNG.sync.write(image));
+    }
+    foreground = `/assets/location-maps/${foregroundFileName}`;
   }
   const firstLayer = map.layers[0];
   return {
     background: `/assets/location-maps/${fileName}`,
+    ...(foreground ? { foreground } : {}),
     width: firstLayer.size.width,
     height: firstLayer.size.height,
     ...(includeBlocked ? { blocked: blockedMapTiles(map) } : {}),
@@ -147,7 +183,7 @@ const farmMapNames = {
 
 function interiorMapName(interior) {
   if (interior.mapName) return interior.mapName;
-  const contextualName = /\/location-maps\/([^/]+)-(?:spring|summer|fall|winter)\.png$/i
+  const contextualName = /\/location-maps\/([^/]+)-(?:spring|summer|fall|winter)(?:-(?:base|foreground))?\.png$/i
     .exec(interior.background || "")?.[1];
   if (contextualName) return contextualName;
   const fileName = /\/([^/]+)\.png$/i.exec(interior.background || "")?.[1];
@@ -215,10 +251,11 @@ async function main() {
     const mapName = interiorMapName(interior);
     if (!mapName) continue;
     try {
-      const rendered = await renderLocation(mapName, season);
+      const rendered = await renderLocation(mapName, season, { layered: true });
       if (!rendered) continue;
       locationMaps[interior.id] = rendered;
       interior.background = rendered.background;
+      interior.foreground = rendered.foreground;
       interior.width = rendered.width;
       interior.height = rendered.height;
     } catch (error) {

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { readFile as readRawFile } from "node:fs/promises";
 import test from "node:test";
+import { furnitureDestination } from "../app/furniture-layout.mjs";
+import { isForegroundMapLayer } from "../scripts/render-community-rooms.mjs";
 
 async function readFile(path, encoding) {
   const source = await readRawFile(path, encoding);
@@ -38,6 +40,67 @@ test("server renders the local Maglucen companion shell", async () => {
   );
   assert.match(html, /Preparing your farm/);
   assert.doesNotMatch(html, /codex-preview|Your site is taking shape/i);
+});
+
+test("furniture sprites anchor to the bottom of their saved collision footprint", async () => {
+  assert.deepEqual(
+    furnitureDestination({
+      x: 4,
+      y: 4,
+      sourceWidth: 16,
+      sourceHeight: 32,
+      footprintHeight: 1,
+    }),
+    [64, 48, 16, 32],
+  );
+  assert.deepEqual(
+    furnitureDestination({
+      x: 5,
+      y: 4,
+      sourceWidth: 32,
+      sourceHeight: 48,
+      footprintHeight: 2,
+    }),
+    [80, 48, 32, 48],
+  );
+  assert.deepEqual(
+    furnitureDestination({
+      x: 7,
+      y: 8,
+      sourceWidth: 32,
+      sourceHeight: 48,
+      footprintHeight: 3,
+    }),
+    [112, 128, 32, 48],
+  );
+
+  const [generator, page] = await Promise.all([
+    readRawFile(new URL("../scripts/generate_snapshot.py", import.meta.url), "utf8"),
+    readRawFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+  ]);
+  assert.match(generator, /item\.find\("boundingBox"\)/);
+  assert.match(generator, /"footprintHeight": footprint_height/);
+  assert.match(page, /furnitureDestination\(entity, size\)/);
+  assert.match(page, /furnitureDestination\(item, TILE\)/);
+});
+
+test("interior foreground map layers occlude furniture like Stardew Valley", async () => {
+  assert.equal(isForegroundMapLayer("Back"), false);
+  assert.equal(isForegroundMapLayer("Buildings"), false);
+  assert.equal(isForegroundMapLayer("Front"), true);
+  assert.equal(isForegroundMapLayer("Front2"), true);
+  assert.equal(isForegroundMapLayer("AlwaysFront"), true);
+
+  const [renderer, page, styles] = await Promise.all([
+    readRawFile(new URL("../scripts/render-storage-location-maps.mjs", import.meta.url), "utf8"),
+    readRawFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+    readRawFile(new URL("../app/globals.css", import.meta.url), "utf8"),
+  ]);
+  assert.match(renderer, /renderLocation\(mapName, season, \{ layered: true \}\)/);
+  assert.match(renderer, /interior\.foreground = rendered\.foreground/);
+  assert.match(page, /ctx\.drawImage\(currentForeground\.image/);
+  assert.match(page, /storage-location-preview-foreground/);
+  assert.match(styles, /\.storage-location-preview-foreground/);
 });
 
 test("the localization context interpolates variables before and after desktop hydration", async () => {
@@ -1223,7 +1286,7 @@ test("physical chests can request locally rendered maps for any game location", 
   assert.match(renderer, /snapshot\.planningBrief\?\.inventory/);
   assert.match(renderer, /resolve\(contentRoot, "Maps", `\$\{name\}\.xnb`\)/);
   assert.match(renderer, /seasonalSheetName\(imageSource, season\)/);
-  assert.match(renderer, /await renderMap\(tbinPath, sheets\)/);
+  assert.match(renderer, /await renderMap\(tbinPath, sheets,/);
   assert.match(renderer, /snapshot\.locationMaps = locationMaps/);
   assert.match(renderer, /liveState\.storage \|\| \[\]/);
   assert.match(renderer, /1: "Farm_Fishing"/);


### PR DESCRIPTION
## Summary
- anchor furniture sprites to the bottom of their saved collision footprint
- preserve Stardew Valley Front/AlwaysFront occlusion above furniture
- continue reading farmhouse maps and tilesheets from the user's local game installation
- cover one-, two-, and three-tile furniture plus foreground layer classification

## Validation
- npm run verify:public
- npm run lint
- npm test (77 passing)
- Windows desktop package passed on #31 and #32

Closes #22