### PR TITLE
fix(localization): keep Companion UI aligned at startup

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -13,12 +13,13 @@ import english from "../locales/en.json";
 import spanish from "../locales/es.json";
 
 type Messages = Record<string, string>;
+export type SupportedAppLanguage = "en" | "es";
 export type MessageDescriptor = {
   key: string;
   variables?: Record<string, string | number | MessageDescriptor>;
 };
 type LocalizationPayload = {
-  language: "en" | "es";
+  language: SupportedAppLanguage;
   locale: string;
   messages: Messages;
   fallbackMessages: Messages;
@@ -43,8 +44,8 @@ const fallback: LocalizationPayload = {
   fallbackMessages: english,
 };
 
-function browserLocalization(): LocalizationPayload {
-  return navigator.language.toLowerCase().startsWith("es")
+function localizationForLanguage(language: SupportedAppLanguage): LocalizationPayload {
+  return language === "es"
     ? {
         language: "es",
         locale: "es-ES",
@@ -52,6 +53,12 @@ function browserLocalization(): LocalizationPayload {
         fallbackMessages: english,
       }
     : fallback;
+}
+
+function browserLocalization(): LocalizationPayload {
+  return localizationForLanguage(
+    navigator.language.toLowerCase().startsWith("es") ? "es" : "en",
+  );
 }
 
 function isLocalizationPayload(value: unknown): value is LocalizationPayload {
@@ -109,8 +116,16 @@ const LocalizationContext = createContext<LocalizationContextValue>({
   date: value => translateMessage(english, english, "date.game", value),
 });
 
-export function LocalizationProvider({ children }: { children: ReactNode }) {
-  const [state, setState] = useState<LocalizationPayload>(fallback);
+export function LocalizationProvider({
+  children,
+  initialLanguage = "en",
+}: {
+  children: ReactNode;
+  initialLanguage?: SupportedAppLanguage;
+}) {
+  const [state, setState] = useState<LocalizationPayload>(() =>
+    localizationForLanguage(initialLanguage),
+  );
 
   useEffect(() => {
     let active = true;
@@ -129,7 +144,10 @@ export function LocalizationProvider({ children }: { children: ReactNode }) {
         return;
       }
       try {
-        const payload = await desktop.getLocalization();
+        const payload = await Promise.race([
+          desktop.getLocalization(),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 1500)),
+        ]);
         if (isLocalizationPayload(payload)) apply(payload);
         else applyBrowserFallback();
       } catch {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { LocalizationProvider } from "./i18n";
+import { LocalizationProvider, type SupportedAppLanguage } from "./i18n";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Maglucen · Stardew Valley Companion",
@@ -9,5 +11,13 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
-  return <html lang="en" suppressHydrationWarning><body><LocalizationProvider>{children}</LocalizationProvider></body></html>;
+  const initialLanguage: SupportedAppLanguage =
+    process.env.STARDEW_TOOL_LANGUAGE === "es" ? "es" : "en";
+  return (
+    <html lang={initialLanguage} suppressHydrationWarning>
+      <body>
+        <LocalizationProvider initialLanguage={initialLanguage}>{children}</LocalizationProvider>
+      </body>
+    </html>
+  );
 }

--- a/tests/localization.test.mjs
+++ b/tests/localization.test.mjs
@@ -103,8 +103,9 @@ test("semantic daily and fishing messages are available in both catalogs", () =>
 });
 
 test("desktop and renderer keep the Companion locale synchronized", async () => {
-  const [provider, preload, desktop] = await Promise.all([
+  const [provider, layout, preload, desktop] = await Promise.all([
     readFile(new URL("../app/i18n.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../app/layout.tsx", import.meta.url), "utf8"),
     readFile(new URL("../desktop/preload.cjs", import.meta.url), "utf8"),
     readFile(new URL("../desktop/main.mjs", import.meta.url), "utf8"),
   ]);
@@ -117,6 +118,11 @@ test("desktop and renderer keep the Companion locale synchronized", async () => 
   assert.match(provider, /desktop\?\.onLocalizationChanged\?\.\(apply\)/);
   assert.match(provider, /window\.addEventListener\("focus", refresh\)/);
   assert.match(provider, /document\.addEventListener\("visibilitychange", handleVisibility\)/);
+  assert.match(provider, /Promise\.race\(\[/);
+  assert.match(provider, /setTimeout\(\(\) => resolve\(null\), 1500\)/);
   assert.match(provider, /catch \{\s*applyBrowserFallback\(\);\s*\}/);
+  assert.match(layout, /export const dynamic = "force-dynamic"/);
+  assert.match(layout, /process\.env\.STARDEW_TOOL_LANGUAGE === "es"/);
+  assert.match(layout, /<LocalizationProvider initialLanguage=\{initialLanguage\}>/);
   assert.doesNotMatch(provider, /getLocalization\(\)\.then\(setState\)\.catch\(\(\) => undefined\)/);
 });


### PR DESCRIPTION
## Cause
The renderer always started from the hard-coded English fallback and waited for an asynchronous Electron localization response. If that startup request stalled, game-owned names could already be Spanish while the Companion UI remained English.

## Fix
- render the first local response using the resolved Companion language
- make the route dynamic so runtime language is not frozen at build time
- initialize the localization provider from that same language
- fall back to the browser locale if Electron localization does not answer within 1.5 seconds
- add regression coverage for initial and runtime synchronization

## Verification
- npm test (78 passed)
- npm run lint
- npm run verify:public
- npx tsc --noEmit
- development response verified as html lang=es before hydration