### PR TITLE
fix(localization): render actual flags and local Stardew icon

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -333,25 +333,15 @@ button {
   flex: 0 0 auto;
 }
 .language-selector-trigger {
-  width: 42px;
+  width: 34px;
   height: 28px;
-  padding: 0 5px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  padding: 3px;
+  display: grid;
+  place-items: center;
   color: #f7ecd8;
   background: #27362c;
   border: 1px solid #61705e;
   cursor: pointer;
-}
-.language-selector-trigger > span {
-  font-size: 16px;
-  line-height: 1;
-}
-.language-selector-trigger > i {
-  color: #aebba9;
-  font: 8px Arial, sans-serif;
-  font-style: normal;
 }
 .language-selector-trigger:hover,
 .language-selector-trigger:focus-visible,
@@ -364,25 +354,25 @@ button {
   z-index: 90;
   top: calc(100% + 8px);
   right: 0;
-  width: 205px;
+  width: 118px;
   padding: 6px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
   background: #202f26;
   border: 1px solid #62715e;
   box-shadow: 0 16px 34px rgba(0, 0, 0, 0.45);
 }
 .language-selector-menu button {
-  width: 100%;
-  min-height: 36px;
-  padding: 6px 8px;
+  width: 32px;
+  height: 32px;
+  padding: 4px;
   display: grid;
-  grid-template-columns: 26px minmax(0, 1fr) 14px;
-  align-items: center;
-  gap: 7px;
+  place-items: center;
   color: #f7ecd8;
   background: transparent;
   border: 1px solid transparent;
   cursor: pointer;
-  text-align: left;
 }
 .language-selector-menu button:hover,
 .language-selector-menu button:focus-visible,
@@ -391,19 +381,52 @@ button {
   border-color: #6f8b70;
   outline: none;
 }
-.language-selector-menu button > span {
-  font-size: 17px;
-}
-.language-selector-menu button > b {
+.language-mode-icon {
+  position: relative;
   overflow: hidden;
-  font: 700 10px Arial, sans-serif;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  width: 22px;
+  height: 16px;
+  display: block;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
-.language-selector-menu button > i {
-  color: #aee486;
-  font: 800 10px Arial, sans-serif;
-  font-style: normal;
+.language-mode-icon.es {
+  background: linear-gradient(to bottom, #aa151b 0 25%, #f1bf00 25% 75%, #aa151b 75% 100%);
+}
+.language-mode-icon.en {
+  background:
+    linear-gradient(33deg, transparent 42%, #fff 42% 48%, #c8102e 48% 54%, #fff 54% 60%, transparent 60%),
+    linear-gradient(-33deg, transparent 42%, #fff 42% 48%, #c8102e 48% 54%, #fff 54% 60%, transparent 60%),
+    linear-gradient(to right, transparent 38%, #fff 38% 62%, transparent 62%),
+    linear-gradient(to bottom, transparent 34%, #fff 34% 66%, transparent 66%),
+    linear-gradient(to right, transparent 44%, #c8102e 44% 56%, transparent 56%),
+    linear-gradient(to bottom, transparent 42%, #c8102e 42% 58%, transparent 58%),
+    #012169;
+}
+.language-mode-icon.game {
+  width: 22px;
+  height: 22px;
+  border: 0;
+  background: #6f914f;
+  box-shadow: inset 0 0 0 2px #263b28, 0 1px 2px rgba(0, 0, 0, 0.4);
+  image-rendering: pixelated;
+}
+.language-mode-icon.game::after {
+  content: "✦";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #f1cf72;
+  font: 700 12px/1 Arial, sans-serif;
+}
+.language-mode-icon.game img {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
 }
 .update-button {
   min-width: 86px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1116,6 +1116,23 @@ type DesktopUpdates = {
   onNavigateHistory?: (callback: (direction: "back" | "forward") => void) => () => void;
 };
 type AppNavigationTarget = { view: ActiveView; section?: string };
+
+function LanguageModeIcon({ mode }: { mode: AppLanguageMode }) {
+  return (
+    <span className={`language-mode-icon ${mode}`} aria-hidden="true">
+      {mode === "game" && (
+        // The executable icon is extracted at runtime from the user's own installation.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src="/assets/ui/stardew-valley-icon.png"
+          alt=""
+          onError={(event) => { event.currentTarget.style.display = "none"; }}
+        />
+      )}
+    </span>
+  );
+}
+
 type FarmAnimal = {
   id: string;
   name: string;
@@ -3592,8 +3609,7 @@ export default function Home() {
             title={t("language.current", { language: t(`language.mode.${languageMode}`) })}
             onClick={() => setShowLanguageMenu((open) => !open)}
           >
-            <span aria-hidden="true">{{ game: "🌱", es: "🇪🇸", en: "🇬🇧" }[languageMode]}</span>
-            <i aria-hidden="true">▾</i>
+            <LanguageModeIcon mode={languageMode} />
           </button>
           {showLanguageMenu && (
             <div className="language-selector-menu" role="menu" aria-label={t("language.selector")}>
@@ -3601,14 +3617,14 @@ export default function Home() {
                 <button
                   type="button"
                   role="menuitemradio"
+                  aria-label={t(`language.mode.${option}`)}
                   aria-checked={languageMode === option}
                   className={languageMode === option ? "active" : ""}
                   key={option}
+                  title={t(`language.mode.${option}`)}
                   onClick={() => void switchLanguage(option)}
                 >
-                  <span aria-hidden="true">{{ game: "🌱", es: "🇪🇸", en: "🇬🇧" }[option]}</span>
-                  <b>{t(`language.mode.${option}`)}</b>
-                  <i aria-hidden="true">{languageMode === option ? "✓" : ""}</i>
+                  <LanguageModeIcon mode={option} />
                 </button>
               ))}
             </div>

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -88,6 +88,30 @@ function log(message) {
   );
 }
 
+async function ensureLocalStardewIcon(config) {
+  const executable = [
+    join(config.stardewPath, "Stardew Valley.exe"),
+    join(config.stardewPath, "StardewValley.exe"),
+  ].find((candidate) => existsSync(candidate));
+  if (!executable) return;
+  const destinations = [
+    join(runtimeRoot, "public", "assets", "ui", "stardew-valley-icon.png"),
+    join(workRoot, "dist", "assets", "ui", "stardew-valley-icon.png"),
+  ];
+  if (destinations.every((destination) => existsSync(destination))) return;
+  try {
+    const icon = await app.getFileIcon(executable, { size: "normal" });
+    if (icon.isEmpty()) return;
+    const png = icon.toPNG();
+    for (const destination of destinations) {
+      mkdirSync(dirname(destination), { recursive: true });
+      writeFileSync(destination, png);
+    }
+  } catch (error) {
+    log(`Local Stardew Valley icon unavailable: ${error?.message || error}`);
+  }
+}
+
 function readJson(file, fallback = null) {
   try {
     return JSON.parse(readFileSync(file, "utf8"));
@@ -892,6 +916,7 @@ async function initialize(config, progress = () => {}) {
     mkdirSync(runtimeRoot, { recursive: true });
     migrateLegacyFarmPreferences(config);
     ensurePython(config);
+    await ensureLocalStardewIcon(config);
     const requiredAssets = [
       "springobjects.png",
       "Objects_2.png",

--- a/tests/localization.test.mjs
+++ b/tests/localization.test.mjs
@@ -134,8 +134,12 @@ test("desktop and renderer keep the Companion locale synchronized", async () => 
   assert.match(layout, /initialMode=\{initialMode\}/);
   assert.match(development, /STARDEW_TOOL_LANGUAGE_MODE: localization\.mode/);
   assert.match(page, /className="language-selector"/);
-  assert.match(page, /\{ game: "🌱", es: "🇪🇸", en: "🇬🇧" \}/);
+  assert.match(page, /function LanguageModeIcon/);
+  assert.match(page, /\/assets\/ui\/stardew-valley-icon\.png/);
   assert.match(styles, /\.language-selector-menu/);
+  assert.match(styles, /\.language-mode-icon\.es/);
+  assert.match(styles, /\.language-mode-icon\.en/);
+  assert.match(desktop, /app\.getFileIcon\(executable, \{ size: "normal" \}\)/);
   assert.match(setup, /id="language-label"/);
   assert.match(setupScript, /element\.hidden = Boolean\(state\.config\)/);
   assert.doesNotMatch(provider, /getLocalization\(\)\.then\(setState\)\.catch\(\(\) => undefined\)/);


### PR DESCRIPTION
## Summary
- replace Windows regional-letter emoji with CSS-rendered Spanish and UK flags
- reduce the language popover to three icon-only choices
- preserve localized tooltips, accessible names and selected state
- obtain Stardew Valley's actual executable icon at runtime from the user's local installation
- keep the locally generated icon ignored and out of source control, with a code-generated fallback

## Verification
- visually inspected the extracted local Stardew chicken icon
- verified all three menu controls expose localized tooltips and accessibility labels
- npm test (78 passed)
- npm run lint
- npm run verify:public
- npx tsc --noEmit