### PR TITLE
fix(localization): switch language without reloading the app

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2120,6 +2120,7 @@ export default function Home() {
       await desktop.setLanguageMode(nextMode);
     } catch (error) {
       setDataLoadError(error instanceof Error ? error.message : t("language.switchFailed"));
+    } finally {
       setSwitchingLanguage(false);
     }
   };

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -1334,8 +1334,6 @@ function installIpc() {
     await initialize(config, (message) =>
       event.sender.send("setup:progress", message),
     );
-    if (mainWindow && !mainWindow.isDestroyed())
-      await mainWindow.loadURL(`http://${localServiceHost}:${servicePort(config)}/`);
     return { ok: true, changed: true };
   });
   ipcMain.handle("display:set-scale", (event, incomingScale) => {

--- a/tests/localization.test.mjs
+++ b/tests/localization.test.mjs
@@ -140,6 +140,12 @@ test("desktop and renderer keep the Companion locale synchronized", async () => 
   assert.match(styles, /\.language-mode-icon\.es/);
   assert.match(styles, /\.language-mode-icon\.en/);
   assert.match(desktop, /app\.getFileIcon\(executable, \{ size: "normal" \}\)/);
+  const liveLanguageHandler = desktop.slice(
+    desktop.indexOf('ipcMain.handle("localization:set-mode"'),
+    desktop.indexOf('ipcMain.handle("display:set-scale"'),
+  );
+  assert.doesNotMatch(liveLanguageHandler, /mainWindow\.loadURL/);
+  assert.match(page, /finally \{\s*setSwitchingLanguage\(false\);\s*\}/);
   assert.match(setup, /id="language-label"/);
   assert.match(setupScript, /element\.hidden = Boolean\(state\.config\)/);
   assert.doesNotMatch(provider, /getLocalization\(\)\.then\(setState\)\.catch\(\(\) => undefined\)/);


### PR DESCRIPTION
## Summary
- apply the Companion catalog immediately in the existing renderer
- keep the window and current page mounted while the local service rebuilds game-localized data
- clear the switching indicator after the background refresh finishes
- add regression coverage preventing a future page reload

## Verification
- npm run lint
- npm test (78 passed)
- npm run verify:public