### PR TITLE
perf(localization): skip redundant language reload

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -21,6 +21,7 @@ export type MessageDescriptor = {
 };
 type LocalizationPayload = {
   mode: AppLanguageMode;
+  gameCode: string;
   language: SupportedAppLanguage;
   locale: string;
   messages: Messages;
@@ -41,6 +42,7 @@ type DesktopLocalization = {
 
 const fallback: LocalizationPayload = {
   mode: "en",
+  gameCode: "en",
   language: "en",
   locale: "en-US",
   messages: english,
@@ -54,12 +56,13 @@ function localizationForLanguage(
   return language === "es"
     ? {
         mode,
+        gameCode: language,
         language: "es",
         locale: "es-ES",
         messages: spanish,
         fallbackMessages: english,
       }
-    : { ...fallback, mode };
+    : { ...fallback, mode, gameCode: language };
 }
 
 function browserLocalization(): LocalizationPayload {
@@ -73,6 +76,7 @@ function isLocalizationPayload(value: unknown): value is LocalizationPayload {
   const candidate = value as Partial<LocalizationPayload>;
   return (
     (candidate.language === "en" || candidate.language === "es") &&
+    typeof candidate.gameCode === "string" &&
     (candidate.mode === "game" || candidate.mode === "en" || candidate.mode === "es") &&
     typeof candidate.locale === "string" &&
     Boolean(candidate.messages) &&

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1096,7 +1096,11 @@ type DesktopUpdates = {
     messages: Record<string, string>;
     fallbackMessages: Record<string, string>;
   }>;
-  setLanguageMode?: (mode: AppLanguageMode) => Promise<{ ok: boolean; changed?: boolean }>;
+  setLanguageMode?: (mode: AppLanguageMode) => Promise<{
+    ok: boolean;
+    changed?: boolean;
+    restarted?: boolean;
+  }>;
   getUpdateState: () => Promise<UpdateState>;
   checkForUpdates: () => Promise<UpdateState>;
   downloadUpdate: () => Promise<UpdateState>;
@@ -1634,7 +1638,7 @@ function drawBuildingSprite(
 }
 
 export default function Home() {
-  const { t, text, locale, mode: languageMode } = useI18n();
+  const { t, text, locale, language, gameCode, mode: languageMode } = useI18n();
   const appShellRef = useRef<HTMLElement>(null);
   const topbarRef = useRef<HTMLElement>(null);
   const [progressTabsTop, setProgressTabsTop] = useState(82);
@@ -2136,13 +2140,17 @@ export default function Home() {
     if (nextMode === languageMode || switchingLanguage) return;
     const desktop = (window as Window & { stardewDesktop?: DesktopUpdates }).stardewDesktop;
     if (!desktop?.setLanguageMode) return;
-    setSwitchingLanguage(true);
+    const nextLanguage = nextMode === "game"
+      ? (gameCode === "es" ? "es" : "en")
+      : nextMode;
+    const requiresRestart = nextLanguage !== language;
+    if (requiresRestart) setSwitchingLanguage(true);
     try {
       await desktop.setLanguageMode(nextMode);
     } catch (error) {
       setDataLoadError(error instanceof Error ? error.message : t("language.switchFailed"));
     } finally {
-      setSwitchingLanguage(false);
+      if (requiresRestart) setSwitchingLanguage(false);
     }
   };
 

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -1317,7 +1317,9 @@ function installIpc() {
     if (!mode) throw new Error(desktopTranslator()("desktop.error.requestRejected"));
     const current = readConfig() || {};
     if (current.languageMode === mode) return { ok: true, changed: false };
+    const currentLanguage = localizationState(current);
     const config = { ...current, languageMode: mode };
+    const nextLanguage = localizationState(config);
     writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
     publishLocalizationState(config);
     Menu.setApplicationMenu(createApplicationMenu());
@@ -1327,6 +1329,8 @@ function installIpc() {
       createTray();
     }
     setupWindow?.webContents.reload();
+    if (currentLanguage.language === nextLanguage.language)
+      return { ok: true, changed: true, restarted: false };
     if (backend && !backend.killed) {
       backend.kill();
       await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
@@ -1334,7 +1338,7 @@ function installIpc() {
     await initialize(config, (message) =>
       event.sender.send("setup:progress", message),
     );
-    return { ok: true, changed: true };
+    return { ok: true, changed: true, restarted: true };
   });
   ipcMain.handle("display:set-scale", (event, incomingScale) => {
     requireDashboardSender(event);

--- a/tests/localization.test.mjs
+++ b/tests/localization.test.mjs
@@ -145,7 +145,10 @@ test("desktop and renderer keep the Companion locale synchronized", async () => 
     desktop.indexOf('ipcMain.handle("display:set-scale"'),
   );
   assert.doesNotMatch(liveLanguageHandler, /mainWindow\.loadURL/);
-  assert.match(page, /finally \{\s*setSwitchingLanguage\(false\);\s*\}/);
+  assert.match(liveLanguageHandler, /currentLanguage\.language === nextLanguage\.language/);
+  assert.match(liveLanguageHandler, /restarted: false/);
+  assert.match(page, /if \(requiresRestart\) setSwitchingLanguage\(true\)/);
+  assert.match(page, /finally \{\s*if \(requiresRestart\) setSwitchingLanguage\(false\);\s*\}/);
   assert.match(setup, /id="language-label"/);
   assert.match(setupScript, /element\.hidden = Boolean\(state\.config\)/);
   assert.doesNotMatch(provider, /getLocalization\(\)\.then\(setState\)\.catch\(\(\) => undefined\)/);


### PR DESCRIPTION
## Summary
- distinguish the selected language mode from the effective UI language
- switch between explicit English/Spanish and matching Stardew mode without a loading state
- persist the selected mode while skipping the local service restart when the effective language is unchanged
- retain the background rebuild when the effective language genuinely changes

## Verification
- npm run lint
- npm test (78 passed)
- npm run verify:public