### PR TITLE
refactor(localization): decouple language from the farm service

### DIFF
--- a/app/i18n.tsx
+++ b/app/i18n.tsx
@@ -19,6 +19,12 @@ export type MessageDescriptor = {
   key: string;
   variables?: Record<string, string | number | MessageDescriptor>;
 };
+export type GameLocalizationCatalog = {
+  localizedObjectNamesByEnglish?: Record<string, string>;
+  localizedNamesByQualifiedId?: Record<string, string>;
+  localizedAchievementsById?: Record<string, { name?: string; requirement?: string }>;
+  localizedQuestsById?: Record<string, { title?: string; description?: string; objective?: string }>;
+};
 type LocalizationPayload = {
   mode: AppLanguageMode;
   gameCode: string;
@@ -26,6 +32,7 @@ type LocalizationPayload = {
   locale: string;
   messages: Messages;
   fallbackMessages: Messages;
+  gameCatalog: GameLocalizationCatalog;
 };
 type LocalizationContextValue = LocalizationPayload & {
   t: (key: string, variables?: Record<string, string | number>) => string;
@@ -47,6 +54,7 @@ const fallback: LocalizationPayload = {
   locale: "en-US",
   messages: english,
   fallbackMessages: english,
+  gameCatalog: {},
 };
 
 function localizationForLanguage(
@@ -61,6 +69,7 @@ function localizationForLanguage(
         locale: "es-ES",
         messages: spanish,
         fallbackMessages: english,
+        gameCatalog: {},
       }
     : { ...fallback, mode, gameCode: language };
 }
@@ -82,7 +91,9 @@ function isLocalizationPayload(value: unknown): value is LocalizationPayload {
     Boolean(candidate.messages) &&
     typeof candidate.messages === "object" &&
     Boolean(candidate.fallbackMessages) &&
-    typeof candidate.fallbackMessages === "object"
+    typeof candidate.fallbackMessages === "object" &&
+    Boolean(candidate.gameCatalog) &&
+    typeof candidate.gameCatalog === "object"
   );
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,12 @@ import {
 import packageMetadata from "../package.json";
 import { ChangelogHistory } from "./changelog";
 import { furnitureDestination } from "./furniture-layout.mjs";
-import { useI18n, type AppLanguageMode, type MessageDescriptor } from "./i18n";
+import {
+  useI18n,
+  type AppLanguageMode,
+  type GameLocalizationCatalog,
+  type MessageDescriptor,
+} from "./i18n";
 
 const APPLICATION_VERSION = packageMetadata.version;
 
@@ -152,6 +157,7 @@ type GrandpaProgress = {
 };
 type Achievement = {
   id: string;
+  gameId?: number | null;
   name: string;
   requirement: string;
   category: string;
@@ -738,9 +744,16 @@ function resolveGameDisplayName(
 function localizeSnapshotGameNames(
   snapshot: Snapshot,
   translate: Translate = (key, variables) => String(variables?.item ?? key),
+  gameCatalog: GameLocalizationCatalog = {},
 ): Snapshot {
-  const byId = snapshot.localizedNamesByQualifiedId || {};
-  const byEnglish = snapshot.localizedObjectNamesByEnglish || {};
+  const byId = {
+    ...(gameCatalog.localizedNamesByQualifiedId || snapshot.localizedNamesByQualifiedId || {}),
+  };
+  const byEnglish = {
+    ...(gameCatalog.localizedObjectNamesByEnglish || snapshot.localizedObjectNamesByEnglish || {}),
+  };
+  snapshot.localizedNamesByQualifiedId = byId;
+  snapshot.localizedObjectNamesByEnglish = byEnglish;
   const registerIdentity = (item: { id?: string; name: string }) => {
     if (!item.id || /^Item\s+\S+$/i.test(item.name)) return;
     const qualifiedId = item.id.startsWith("(") ? item.id : `(O)${item.id}`;
@@ -807,6 +820,12 @@ function localizeSnapshotGameNames(
     ...(snapshot.dailyBrief.acceptedQuests || []),
     ...(snapshot.dailyBrief.boardQuest ? [snapshot.dailyBrief.boardQuest] : []),
   ]) {
+    const localizedQuest = quest.id === undefined || quest.daily
+      ? undefined
+      : gameCatalog.localizedQuestsById?.[String(quest.id)];
+    if (localizedQuest?.title) quest.title = localizedQuest.title;
+    if (localizedQuest?.description) quest.description = localizedQuest.description;
+    if (localizedQuest?.objective) quest.objective = localizedQuest.objective;
     quest.stock.forEach(item => Object.assign(item, { displayName: localizedName(item.name) }));
     if (quest.requestedName)
       quest.requestedName = localizedName(quest.requestedName, quest.requestedId || undefined);
@@ -817,6 +836,12 @@ function localizeSnapshotGameNames(
     snapshot.collectionBrief?.crafting,
   ]) group?.forEach(attach);
   snapshot.museumBrief.sources.flatMap(source => source.items || []).forEach(attach);
+  snapshot.achievements.items.forEach((achievement) => {
+    if (achievement.gameId === undefined || achievement.gameId === null) return;
+    const localized = gameCatalog.localizedAchievementsById?.[String(achievement.gameId)];
+    if (localized?.name) achievement.name = localized.name;
+    if (localized?.requirement) achievement.requirement = localized.requirement;
+  });
   return snapshot;
 }
 
@@ -1638,7 +1663,7 @@ function drawBuildingSprite(
 }
 
 export default function Home() {
-  const { t, text, locale, language, gameCode, mode: languageMode } = useI18n();
+  const { t, text, locale, gameCatalog, mode: languageMode } = useI18n();
   const appShellRef = useRef<HTMLElement>(null);
   const topbarRef = useRef<HTMLElement>(null);
   const [progressTabsTop, setProgressTabsTop] = useState(82);
@@ -1704,7 +1729,7 @@ export default function Home() {
   const [showFarmSwitcher, setShowFarmSwitcher] = useState(false);
   const farmSwitcherRef = useRef<HTMLDivElement>(null);
   const [showLanguageMenu, setShowLanguageMenu] = useState(false);
-  const [switchingLanguage, setSwitchingLanguage] = useState(false);
+  const languageSwitchingRef = useRef(false);
   const languageMenuRef = useRef<HTMLDivElement>(null);
   const [showHelp, setShowHelp] = useState(false);
   const [showAppSearch, setShowAppSearch] = useState(false);
@@ -2137,20 +2162,16 @@ export default function Home() {
 
   const switchLanguage = async (nextMode: AppLanguageMode) => {
     setShowLanguageMenu(false);
-    if (nextMode === languageMode || switchingLanguage) return;
+    if (nextMode === languageMode || languageSwitchingRef.current) return;
     const desktop = (window as Window & { stardewDesktop?: DesktopUpdates }).stardewDesktop;
     if (!desktop?.setLanguageMode) return;
-    const nextLanguage = nextMode === "game"
-      ? (gameCode === "es" ? "es" : "en")
-      : nextMode;
-    const requiresRestart = nextLanguage !== language;
-    if (requiresRestart) setSwitchingLanguage(true);
+    languageSwitchingRef.current = true;
     try {
       await desktop.setLanguageMode(nextMode);
     } catch (error) {
       setDataLoadError(error instanceof Error ? error.message : t("language.switchFailed"));
     } finally {
-      if (requiresRestart) setSwitchingLanguage(false);
+      languageSwitchingRef.current = false;
     }
   };
 
@@ -2341,7 +2362,7 @@ export default function Home() {
         }),
       ])
         .then(([snapshot, farmHistory]: [Snapshot, FarmHistory]) => {
-          snapshot = localizeSnapshotGameNames(snapshot, t);
+          snapshot = localizeSnapshotGameNames(snapshot, t, gameCatalog);
           const profileId = snapshot.profileId || "default";
           const sessionStorageKey = `stardew-tool-last-session-${profileId}`;
           if (sessionProfileRef.current !== profileId) {
@@ -2398,7 +2419,7 @@ export default function Home() {
       asset.src = path;
     });
     return () => window.clearInterval(refreshTimer);
-  }, [t]);
+  }, [t, gameCatalog]);
 
   useEffect(() => {
     const path = data?.locationMaps?.Farm?.background;
@@ -2436,12 +2457,16 @@ export default function Home() {
       .then((snapshot) =>
         setPreviousDay(
           snapshot
-            ? localizeSnapshotGameNames({ ...snapshot, seasonLabel: seasonName(snapshot.season) }, t)
+            ? localizeSnapshotGameNames(
+                { ...snapshot, seasonLabel: seasonName(snapshot.season) },
+                t,
+                gameCatalog,
+              )
             : null,
         ),
       )
       .catch(() => setPreviousDay(null));
-  }, [data, history, t]);
+  }, [data, gameCatalog, history, t]);
 
   useEffect(() => {
     if (!data || mapLocation === "farm") return;
@@ -3347,15 +3372,6 @@ export default function Home() {
           </div>
         </div>
       )}
-      {switchingLanguage && (
-        <div className="farm-switch-feedback" role="status" aria-live="assertive">
-          <span className="farm-switch-spinner" aria-hidden="true" />
-          <div>
-            <strong>{t("language.switching")}</strong>
-            <span>{t("language.switchingDetail")}</span>
-          </div>
-        </div>
-      )}
       <header className="topbar" ref={topbarRef}>
         <div className="brand">
           {/* The selected save's farmer is composed locally from the user's own game assets. */}
@@ -3635,7 +3651,6 @@ export default function Home() {
             aria-label={t("language.current", { language: t(`language.mode.${languageMode}`) })}
             aria-expanded={showLanguageMenu}
             aria-haspopup="menu"
-            disabled={switchingLanguage}
             title={t("language.current", { language: t(`language.mode.${languageMode}`) })}
             onClick={() => setShowLanguageMenu((open) => !open)}
           >

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -187,6 +187,10 @@ function localizationPayload(config = readConfig() || {}) {
     ...state,
     messages: localizationCatalog(state.language),
     fallbackMessages: localizationCatalog("en"),
+    gameCatalog: readJson(
+      join(runtimeRoot, "public", "data", `game-localization.${state.language}.json`),
+      {},
+    ),
   };
 }
 
@@ -375,8 +379,7 @@ function extractedAssetsAreStale(config, requiredAssets) {
   if (!existsSync(gameData)) return true;
   const extracted = readJson(gameData, {});
   if (
-    extracted?._localization?.language !== localizationState(config).language ||
-    extracted?._localization?.catalogVersion !== 5
+    extracted?._localization?.catalogVersion !== 6
   )
     return true;
   return (
@@ -931,6 +934,8 @@ async function initialize(config, progress = () => {}) {
       "Slime Hutch.png",
     ].map((name) => join(runtimeRoot, "public", "assets", "sprites", name));
     requiredAssets.push(
+      join(runtimeRoot, "public", "data", "game-localization.en.json"),
+      join(runtimeRoot, "public", "data", "game-localization.es.json"),
       join(runtimeRoot, "public", "assets", "characters", "Abigail.png"),
       join(runtimeRoot, "public", "assets", "portraits", "Abigail.png"),
       join(runtimeRoot, "public", "assets", "maps", "world-spring.png"),
@@ -1317,9 +1322,7 @@ function installIpc() {
     if (!mode) throw new Error(desktopTranslator()("desktop.error.requestRejected"));
     const current = readConfig() || {};
     if (current.languageMode === mode) return { ok: true, changed: false };
-    const currentLanguage = localizationState(current);
     const config = { ...current, languageMode: mode };
-    const nextLanguage = localizationState(config);
     writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
     publishLocalizationState(config);
     Menu.setApplicationMenu(createApplicationMenu());
@@ -1329,16 +1332,7 @@ function installIpc() {
       createTray();
     }
     setupWindow?.webContents.reload();
-    if (currentLanguage.language === nextLanguage.language)
-      return { ok: true, changed: true, restarted: false };
-    if (backend && !backend.killed) {
-      backend.kill();
-      await new Promise((resolvePromise) => setTimeout(resolvePromise, 500));
-    }
-    await initialize(config, (message) =>
-      event.sender.send("setup:progress", message),
-    );
-    return { ok: true, changed: true, restarted: true };
+    return { ok: true, changed: true, restarted: false };
   });
   ipcMain.handle("display:set-scale", (event, incomingScale) => {
     requireDashboardSender(event);

--- a/scripts/extract_game_data.mjs
+++ b/scripts/extract_game_data.mjs
@@ -12,9 +12,6 @@ const errors = validateConfig(config, { requireSave: false });
 if (errors.length) throw new Error(errors.join(" "));
 const project = runtimeRoot;
 const { contentRoot, modsRoot } = runtimePaths(config);
-const language = process.env.STARDEW_TOOL_LANGUAGE === "es" ? "es" : "en";
-const locale = process.env.STARDEW_TOOL_LOCALE || (language === "es" ? "es-ES" : "en-US");
-const xnbSuffix = process.env.STARDEW_TOOL_XNB_SUFFIX || "";
 ensureRuntimeDirectories();
 
 async function unpack(relativePath) {
@@ -27,8 +24,8 @@ async function unpack(relativePath) {
   return parsed.content;
 }
 
-async function unpackLocalized(relativePath) {
-  return unpack(localizedXnbPath(contentRoot, relativePath, xnbSuffix));
+async function unpackLocalized(relativePath, suffix = "") {
+  return unpack(localizedXnbPath(contentRoot, relativePath, suffix));
 }
 
 async function unpackTexture(relativePath, destination) {
@@ -51,9 +48,9 @@ async function unpackBinary(relativePath, extension, destination) {
   await writeFile(resolve(project, destination), Buffer.from(await output.data.arrayBuffer()));
 }
 
-async function localizedNamesByEnglish(relativePath, includeKey) {
+async function localizedNamesByEnglish(relativePath, includeKey, suffix) {
   const base = await unpack(relativePath);
-  const localized = await unpackLocalized(relativePath);
+  const localized = await unpackLocalized(relativePath, suffix);
   return Object.fromEntries(
     Object.entries(base).flatMap(([key, english]) =>
       includeKey(key) && typeof english === "string" && localized[key]
@@ -63,9 +60,9 @@ async function localizedNamesByEnglish(relativePath, includeKey) {
   );
 }
 
-async function localizedLegacyRecordNames(relativePath) {
+async function localizedLegacyRecordNames(relativePath, suffix) {
   const base = await unpack(relativePath);
-  const localized = await unpackLocalized(relativePath);
+  const localized = await unpackLocalized(relativePath, suffix);
   return Object.fromEntries(
     Object.entries(base).flatMap(([key, raw]) => {
       const localizedRaw = localized[key];
@@ -88,44 +85,70 @@ const nameCatalogs = [
   ["Strings/Shirts.xnb", key => key.endsWith("_Name")],
   ["Strings/Furniture.xnb", () => true],
 ];
-const localizedObjectNamesByEnglish = Object.assign(
-  {},
-  ...(await Promise.all(
-    nameCatalogs.map(([path, includeKey]) =>
-      localizedNamesByEnglish(path, includeKey),
-    ),
-  )),
-  await localizedLegacyRecordNames("Data/Boots.xnb"),
-  await localizedLegacyRecordNames("Data/hats.xnb"),
-);
-const localizedObjectNames = await unpackLocalized("Strings/Objects.xnb");
 const fish = await unpack("Data/Fish.xnb");
-const localizedAchievementRecords = await unpackLocalized("Data/Achievements.xnb");
-const localizedQuestRecords = await unpackLocalized("Data/Quests.xnb");
-const localizedAchievementsById = Object.fromEntries(
-  Object.entries(localizedAchievementRecords).map(([id, raw]) => {
-    const fields = String(raw).split("^");
-    const name = fields[0].replace(/\s+\([^)]*\)$/, "");
-    const requirement = (fields[1] || "").replace(/(\d)o\b/g, "$1g");
-    return [id, { name, requirement }];
-  }),
+async function buildGameLocalizationCatalog(catalogLanguage, catalogLocale, catalogSuffix) {
+  const localizedObjectNamesByEnglish = Object.assign(
+    {},
+    ...(await Promise.all(
+      nameCatalogs.map(([path, includeKey]) =>
+        localizedNamesByEnglish(path, includeKey, catalogSuffix),
+      ),
+    )),
+    await localizedLegacyRecordNames("Data/Boots.xnb", catalogSuffix),
+    await localizedLegacyRecordNames("Data/hats.xnb", catalogSuffix),
+  );
+  const objectNames = await unpackLocalized("Strings/Objects.xnb", catalogSuffix);
+  const localizedAchievementRecords = await unpackLocalized("Data/Achievements.xnb", catalogSuffix);
+  const localizedQuestRecords = await unpackLocalized("Data/Quests.xnb", catalogSuffix);
+  const localizedAchievementsById = Object.fromEntries(
+    Object.entries(localizedAchievementRecords).map(([id, raw]) => {
+      const fields = String(raw).split("^");
+      const name = fields[0].replace(/\s+\([^)]*\)$/, "");
+      const requirement = (fields[1] || "").replace(/(\d)o\b/g, "$1g");
+      return [id, { name, requirement }];
+    }),
+  );
+  const localizedQuestsById = Object.fromEntries(
+    Object.entries(localizedQuestRecords).map(([id, raw]) => {
+      const fields = String(raw).split("/");
+      return [id, { title: fields[1] || "", description: fields[2] || "", objective: fields[3] || "" }];
+    }),
+  );
+  const localizedNamesByQualifiedId = Object.fromEntries(
+    Object.entries(fish).flatMap(([id, raw]) => {
+      const englishName = typeof raw === "string" ? raw.split("/", 1)[0] : "";
+      const localizedName = localizedObjectNamesByEnglish[englishName];
+      return localizedName ? [[`(O)${id}`, localizedName]] : [];
+    }),
+  );
+  return {
+    language: catalogLanguage,
+    locale: catalogLocale,
+    catalogVersion: 6,
+    objectNames,
+    localizedObjectNamesByEnglish,
+    localizedNamesByQualifiedId,
+    localizedAchievementsById,
+    localizedQuestsById,
+    specialOrderStrings: await unpackLocalized("Strings/SpecialOrderStrings.xnb", catalogSuffix),
+  };
+}
+
+const gameLocalizationCatalogs = Object.fromEntries(
+  await Promise.all([
+    ["en", "en-US", ""],
+    ["es", "es-ES", "es-ES"],
+  ].map(async ([catalogLanguage, catalogLocale, catalogSuffix]) => [
+    catalogLanguage,
+    await buildGameLocalizationCatalog(catalogLanguage, catalogLocale, catalogSuffix),
+  ])),
 );
-const localizedQuestsById = Object.fromEntries(
-  Object.entries(localizedQuestRecords).map(([id, raw]) => {
-    const fields = String(raw).split("/");
-    return [id, { title: fields[1] || "", description: fields[2] || "", objective: fields[3] || "" }];
-  }),
-);
-const localizedNamesByQualifiedId = Object.fromEntries(
-  Object.entries(fish).flatMap(([id, raw]) => {
-    const englishName = typeof raw === "string" ? raw.split("/", 1)[0] : "";
-    const localizedName = localizedObjectNamesByEnglish[englishName];
-    return localizedName ? [[`(O)${id}`, localizedName]] : [];
-  }),
-);
+// Snapshot generation always consumes the stable English/base catalog. The
+// renderer selects a cached game catalog independently from the save logic.
+const activeLocalization = gameLocalizationCatalogs.en;
 
 const gameData = {
-  _localization: { language, locale, xnbSuffix, catalogVersion: 5 },
+  _localization: { language: "neutral", catalogVersion: 6 },
   giftTastes: await unpack("Data/NPCGiftTastes.xnb"),
   cookingRecipes: await unpack("Data/CookingRecipes.xnb"),
   craftingRecipes: await unpack("Data/CraftingRecipes.xnb"),
@@ -135,12 +158,12 @@ const gameData = {
   hair: await unpack("Data/HairData.xnb"),
   hats: await unpack("Data/hats.xnb"),
   furniture: await unpack("Data/Furniture.xnb"),
-  objectNames: localizedObjectNames,
-  localizedObjectNamesByEnglish,
-  localizedNamesByQualifiedId,
-  localizedAchievementsById,
-  localizedQuestsById,
-  specialOrderStrings: await unpackLocalized("Strings/SpecialOrderStrings.xnb"),
+  objectNames: activeLocalization.objectNames,
+  localizedObjectNamesByEnglish: activeLocalization.localizedObjectNamesByEnglish,
+  localizedNamesByQualifiedId: activeLocalization.localizedNamesByQualifiedId,
+  localizedAchievementsById: activeLocalization.localizedAchievementsById,
+  localizedQuestsById: activeLocalization.localizedQuestsById,
+  specialOrderStrings: activeLocalization.specialOrderStrings,
 };
 
 const textures = {
@@ -324,6 +347,15 @@ async function discoverModdedNpcs() {
 const moddedNpcs = await discoverModdedNpcs();
 gameData.moddedCharacters = moddedNpcs.metadata;
 Object.assign(gameData.giftTastes, moddedNpcs.giftTastes);
-await writeFile(resolve(project, "assetbuild/game-data.json"), JSON.stringify(gameData), "utf8");
+await Promise.all([
+  writeFile(resolve(project, "assetbuild/game-data.json"), JSON.stringify(gameData), "utf8"),
+  ...Object.entries(gameLocalizationCatalogs).map(([catalogLanguage, catalog]) =>
+    writeFile(
+      resolve(project, `public/data/game-localization.${catalogLanguage}.json`),
+      JSON.stringify(catalog),
+      "utf8",
+    ),
+  ),
+]);
 if (moddedNpcs.artworkCount) console.log(`Imported ${moddedNpcs.artworkCount} modded NPC artwork files.`);
 syncRuntimePublic();

--- a/scripts/generate_snapshot.py
+++ b/scripts/generate_snapshot.py
@@ -1831,7 +1831,7 @@ def achievement_tracking(root: ET.Element, player: ET.Element, total_earned: int
         name = localized_achievement.get("name") or name
         requirement = localized_achievement.get("requirement") or requirement
         achievements.append({
-            "id": key, "name": name, "requirement": requirement, "category": category,
+            "id": key, "gameId": save_id, "name": name, "requirement": requirement, "category": category,
             "done": done, "current": current, "target": target, "unit": unit,
             "timing": timing, "nextStep": next_step,
         })

--- a/tests/localization.test.mjs
+++ b/tests/localization.test.mjs
@@ -145,10 +145,13 @@ test("desktop and renderer keep the Companion locale synchronized", async () => 
     desktop.indexOf('ipcMain.handle("display:set-scale"'),
   );
   assert.doesNotMatch(liveLanguageHandler, /mainWindow\.loadURL/);
-  assert.match(liveLanguageHandler, /currentLanguage\.language === nextLanguage\.language/);
+  assert.doesNotMatch(liveLanguageHandler, /backend\.kill\(\)/);
+  assert.doesNotMatch(liveLanguageHandler, /await initialize\(/);
   assert.match(liveLanguageHandler, /restarted: false/);
-  assert.match(page, /if \(requiresRestart\) setSwitchingLanguage\(true\)/);
-  assert.match(page, /finally \{\s*if \(requiresRestart\) setSwitchingLanguage\(false\);\s*\}/);
+  assert.match(desktop, /game-localization\.\$\{state\.language\}\.json/);
+  assert.match(provider, /gameCatalog: GameLocalizationCatalog/);
+  assert.match(page, /localizeSnapshotGameNames\(snapshot, t, gameCatalog\)/);
+  assert.doesNotMatch(page, /setSwitchingLanguage/);
   assert.match(setup, /id="language-label"/);
   assert.match(setupScript, /element\.hidden = Boolean\(state\.config\)/);
   assert.doesNotMatch(provider, /getLocalization\(\)\.then\(setState\)\.catch\(\(\) => undefined\)/);

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1604,8 +1604,10 @@ test("Farm, Plan, and Progress share storage, goals, history, and completion dat
   assert.match(extractor, /Strings\/Furniture\.xnb/);
   assert.match(extractor, /Data\/Boots\.xnb/);
   assert.match(extractor, /Data\/hats\.xnb/);
-  assert.match(extractor, /catalogVersion: 5/);
-  assert.match(desktop, /catalogVersion !== 5/);
+  assert.match(extractor, /catalogVersion: 6/);
+  assert.match(desktop, /catalogVersion !== 6/);
+  assert.match(extractor, /game-localization\.\$\{catalogLanguage\}\.json/);
+  assert.match(extractor, /const activeLocalization = gameLocalizationCatalogs\.en/);
   assert.match(extractor, /Data\/Achievements\.xnb/);
   assert.match(extractor, /replace\(\/\(\\d\)o\\b\/g, "\$1g"\)/);
   assert.match(extractor, /Data\/Quests\.xnb/);
@@ -1704,10 +1706,10 @@ test("game-owned names are localized once for every snapshot-backed view", async
   assert.match(page, /snapshot\.museumBrief\.sources\.flatMap/);
   assert.match(page, /material\.displayName \|\| material\.name/);
   assert.match(page, /machine\.displayName \|\| machine\.name/);
-  assert.match(page, /snapshot = localizeSnapshotGameNames\(snapshot, t\)/);
+  assert.match(page, /snapshot = localizeSnapshotGameNames\(snapshot, t, gameCatalog\)/);
   assert.match(page, /if \(document\.hidden \|\| loadingLatest\) return Promise\.resolve\(\)/);
   assert.match(page, /\.finally\(\(\) => \{\s*loadingLatest = false;/);
-  assert.match(page, /localizeSnapshotGameNames\(\{ \.\.\.snapshot, seasonLabel:/);
+  assert.match(page, /localizeSnapshotGameNames\([\s\S]*?\{ \.\.\.snapshot, seasonLabel:[\s\S]*?gameCatalog/);
   assert.match(page, /live\.routeState\?\.worldTasks/);
   assert.match(page, /item\.displayName \|\| resolveGameDisplayName\(/);
 });


### PR DESCRIPTION
## Summary
- extract and cache English and Spanish Stardew catalogs once from the user's local installation
- keep snapshot generation on a stable language-neutral base
- deliver the active game catalog with the renderer localization state
- relocalize item names, standard quests, achievements, and historical snapshots in the renderer
- switch language without killing the backend, reparsing the save, reloading the page, or showing the farm-loading overlay

## Local verification
- generated both game localization catalogs from the configured local Stardew installation
- verified Wood/Madera and Meet The Wizard/Visita al mago catalog pairs
- npm run lint
- npm test (78 passed)
- npm run verify:public
- node --check scripts/extract_game_data.mjs
- node --check desktop/main.mjs
- python -m py_compile scripts/generate_snapshot.py