### PR TITLE
build: add verified local packaging tools

### DIFF
--- a/LOCAL_BUILD.md
+++ b/LOCAL_BUILD.md
@@ -1,0 +1,34 @@
+# Local Windows builds
+
+Local builds let maintainers verify and package Maglucen Stardew Valley Companion without waiting for GitHub Actions. They are test builds only: public releases must still be produced by the pinned GitHub Actions release workflow so their source, checksums, and provenance can be verified.
+
+## Requirements
+
+- Windows 10 or later.
+- Node.js 22.13 or later.
+- A legitimate local Stardew Valley installation, or `STARDEW_PATH` pointing to compatible public reference assemblies for bridge compilation.
+- Dependencies installed with `npm ci`.
+
+## Commands
+
+Run the complete release-quality validation without packaging:
+
+```powershell
+npm run local:verify
+```
+
+Build and inspect an unpacked application for quick local testing:
+
+```powershell
+npm run local:unpacked
+```
+
+Build and inspect a local NSIS installer:
+
+```powershell
+npm run local:installer
+```
+
+Outputs are written to the ignored `release/` directory. The packaging helper inspects the ASAR and fails if it finds extracted Stardew Valley assets, generated farm data, saves, logs, history, snapshots, or `config.local.json`.
+
+The local installer is intentionally not published or attested. To publish an official version, merge the verified source into `main` and push its matching `vX.Y.Z` tag so `.github/workflows/release.yml` can build the release.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Use [GitHub Issues](https://github.com/Maglucen-Studio/StardewValleyTool/issues)
 
 This is the canonical source, distribution, and support repository for Maglucen Stardew Valley Companion. Stable installers are built from public tagged source by GitHub Actions. The workflow publishes SHA-256 checksums and a build-provenance attestation with each new release.
 
-The source is available under the [MIT License](LICENSE). See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing changes, [CODE_SIGNING_POLICY.md](CODE_SIGNING_POLICY.md) for release-signing governance, [SECURITY.md](SECURITY.md) for private vulnerability reports, [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for dependency notices, and [AI_USAGE.md](AI_USAGE.md) for the project's AI-assisted development disclosure.
+The source is available under the [MIT License](LICENSE). See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing changes, [LOCAL_BUILD.md](LOCAL_BUILD.md) for verified local test builds and installers, [CODE_SIGNING_POLICY.md](CODE_SIGNING_POLICY.md) for release-signing governance, [SECURITY.md](SECURITY.md) for private vulnerability reports, [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for dependency notices, and [AI_USAGE.md](AI_USAGE.md) for the project's AI-assisted development disclosure.
 
 Stardew Valley assets and game assemblies are deliberately absent. Required images and data are extracted locally from each user's legitimate game installation. Continuous integration compiles the optional SMAPI bridge against public API-only reference assemblies.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node scripts/dev-local.mjs",
     "build": "npm run verify:changelog && vinext build && node scripts/prepare-built-public.mjs",
     "start": "vinext start",
-    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs",
+    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs",
     "verify:changelog": "node scripts/verify-changelog.mjs",
     "verify:localization": "node scripts/verify-localization-ui.mjs",
     "verify:public": "node scripts/verify-public-safety.mjs",
@@ -27,7 +27,10 @@
     "desktop:dist": "npm run desktop:installer",
     "desktop:installer": "npm run desktop:bridge && npm run desktop:game-data && npm run build && node scripts/prepare-portable-python.mjs && npm run electron:prepare && electron-builder --win nsis --publish never",
     "desktop:portable": "npm run desktop:bridge && npm run desktop:game-data && npm run build && node scripts/prepare-portable-python.mjs && npm run electron:prepare && electron-builder --win portable",
-    "desktop:dir": "npm run desktop:bridge && npm run desktop:game-data && npm run build && node scripts/prepare-portable-python.mjs && npm run electron:prepare && electron-builder --win dir"
+    "desktop:dir": "npm run desktop:bridge && npm run desktop:game-data && npm run build && node scripts/prepare-portable-python.mjs && npm run electron:prepare && electron-builder --win dir",
+    "local:verify": "node scripts/local-package.mjs verify",
+    "local:unpacked": "node scripts/local-package.mjs unpacked",
+    "local:installer": "node scripts/local-package.mjs installer"
   },
   "dependencies": {
     "electron-updater": "^6.8.9",

--- a/scripts/local-package.mjs
+++ b/scripts/local-package.mjs
@@ -1,0 +1,87 @@
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const projectRoot = resolve(fileURLToPath(new URL("../", import.meta.url)));
+const forbiddenPackagePaths = [
+  /^public[\\/]assets(?:[\\/]|$)/i,
+  /^public[\\/]data(?:[\\/]|$)/i,
+  /^assetbuild[\\/]unpacked(?:[\\/]|$)/i,
+  /(?:^|[\\/])config\.local\.json$/i,
+  /(?:^|[\\/])SaveGameInfo$/i,
+  /(?:^|[\\/])(?:logs?|snapshots?|history)(?:[\\/]|$)/i,
+];
+
+export function validatePackageEntries(entries) {
+  return entries
+    .map((entry) => String(entry).replace(/^[/\\]+/, ""))
+    .filter((entry) => forbiddenPackagePaths.some((pattern) => pattern.test(entry)));
+}
+
+function runNpm(script) {
+  const npmCli = process.env.npm_execpath;
+  if (!npmCli || !existsSync(npmCli)) throw new Error("Run this helper through one of the npm run local:* commands.");
+  const result = spawnSync(process.execPath, [npmCli, "run", script], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`npm run ${script} failed with code ${result.status}.`);
+}
+
+function listAsarEntries(asarPath) {
+  const asarCli = resolve(projectRoot, "node_modules/@electron/asar/bin/asar.js");
+  if (!existsSync(asarCli)) throw new Error("The local ASAR inspection tool is missing. Run npm ci first.");
+  const result = spawnSync(process.execPath, [asarCli, "list", asarPath], {
+    cwd: projectRoot,
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(result.stderr || `Could not inspect ${asarPath}.`);
+  return result.stdout.split(/\r?\n/).filter(Boolean);
+}
+
+export function inspectLocalPackage(root = projectRoot) {
+  const releaseRoot = resolve(root, "release");
+  const asarPath = resolve(releaseRoot, "win-unpacked/resources/app.asar");
+  if (!existsSync(asarPath)) throw new Error("The unpacked application is missing from release/win-unpacked.");
+
+  const unsafeEntries = validatePackageEntries(listAsarEntries(asarPath));
+  if (unsafeEntries.length > 0) {
+    throw new Error(`The local package contains forbidden runtime or private files:\n${unsafeEntries.join("\n")}`);
+  }
+
+  const outputs = readdirSync(releaseRoot, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort();
+  console.log(`Local package inspection passed (${outputs.length} distributable file${outputs.length === 1 ? "" : "s"}).`);
+  return outputs;
+}
+
+function verify() {
+  for (const script of ["verify:public", "audit:runtime", "lint", "test"]) runNpm(script);
+}
+
+function main() {
+  const mode = process.argv[2] || "verify";
+  if (!new Set(["verify", "unpacked", "installer"]).has(mode)) {
+    throw new Error("Usage: node scripts/local-package.mjs <verify|unpacked|installer>");
+  }
+
+  verify();
+  if (mode === "verify") return;
+
+  runNpm(mode === "installer" ? "desktop:installer" : "desktop:dir");
+  const outputs = inspectLocalPackage();
+  if (mode === "installer" && !outputs.some((name) => /Setup-.*\.exe$/i.test(name))) {
+    throw new Error("The NSIS installer was not produced in the release directory.");
+  }
+
+  console.log("Local test build complete. Public releases must still be created from the verified GitHub Actions workflow.");
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) main();

--- a/tests/local-package.test.mjs
+++ b/tests/local-package.test.mjs
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { validatePackageEntries } from "../scripts/local-package.mjs";
+
+test("local package inspection rejects game assets and private runtime data", () => {
+  assert.deepEqual(validatePackageEntries([
+    "/dist/index.html",
+    "/public/app-icon.png",
+    "/public/assets/sprites/springobjects.png",
+    "/public/data/days/latest.json",
+    "/config.local.json",
+    "/farm/history/checkpoint.json",
+  ]), [
+    "public/assets/sprites/springobjects.png",
+    "public/data/days/latest.json",
+    "config.local.json",
+    "farm/history/checkpoint.json",
+  ]);
+});
+
+test("local package inspection accepts application-owned distributable files", () => {
+  assert.deepEqual(validatePackageEntries([
+    "/dist/index.html",
+    "/desktop/main.mjs",
+    "/locales/en.json",
+    "/scripts/generate_snapshot.py",
+  ]), []);
+});


### PR DESCRIPTION
## Summary
- add local verification, unpacked-build, and installer commands
- inspect packaged ASAR contents for extracted game assets and private runtime data
- document local test-build requirements and official-release boundary

## Validation
- npm run local:verify (114 tests)
- npm run local:unpacked
- local ASAR safety inspection passed