### PR TITLE
build(deps-dev): bump fflate to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4190,9 +4190,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
-      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.5.tgz",
+      "integrity": "sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Updates the transitive development dependency fflate from 0.7.4 to 0.7.5, resolving GHSA-px8p-9vwx-vf98. Runtime dependencies are unaffected.

The combined dependency set has already passed npm audit, public safety verification, lint, all 114 tests, and a local Windows package build on PR #62.