### PR TITLE
fix(farms): isolate history and LIVE selection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -506,7 +506,7 @@ type HistoryEntry = {
   petFriendship?: number;
   annotations?: LocalizedValue[];
 };
-type FarmHistory = { farmName: string; entries: HistoryEntry[] };
+type FarmHistory = { profileId: string; farmName: string; entries: HistoryEntry[] };
 type SessionSummary = {
   profileId: string;
   capturedAt: number;
@@ -640,6 +640,7 @@ type LiveQuest = {
 };
 type LiveState = {
   active: boolean;
+  profileId?: string;
   updatedAt?: string | number;
   dateKey?: string;
   timeOfDay?: number;
@@ -1704,6 +1705,7 @@ export default function Home() {
   const [data, setData] = useState<Snapshot | null>(null);
   const [previousDay, setPreviousDay] = useState<Snapshot | null>(null);
   const [history, setHistory] = useState<FarmHistory>({
+    profileId: "",
     farmName: "Farm",
     entries: [],
   });
@@ -2332,6 +2334,7 @@ export default function Home() {
   }, []);
 
   useEffect(() => {
+    const expectedProfileId = data?.profileId;
     const loadLive = () => {
       if (document.hidden) return Promise.resolve();
       return fetch(`/data/live-state.json?live=${Date.now()}`, {
@@ -2347,10 +2350,16 @@ export default function Home() {
           setLive((previous) => {
             const next = {
               ...payload,
-              active: Boolean(payload.active && fresh),
+              active: Boolean(
+                payload.active &&
+                fresh &&
+                expectedProfileId &&
+                payload.profileId === expectedProfileId
+              ),
             };
             return previous.updatedAt === next.updatedAt &&
-              previous.active === next.active
+              previous.active === next.active &&
+              previous.profileId === next.profileId
               ? previous
               : next;
           });
@@ -2364,7 +2373,7 @@ export default function Home() {
     loadLive();
     const timer = window.setInterval(loadLive, 1000);
     return () => window.clearInterval(timer);
-  }, []);
+  }, [data?.profileId]);
 
   useEffect(() => {
     window.localStorage.setItem(
@@ -2411,9 +2420,12 @@ export default function Home() {
         .then(([snapshot, farmHistory]: [Snapshot, FarmHistory]) => {
           snapshot = localizeSnapshotGameNames(snapshot, t, gameCatalog);
           const profileId = snapshot.profileId || "default";
+          if (farmHistory.profileId !== profileId) return;
           const sessionStorageKey = `stardew-tool-last-session-${profileId}`;
           if (sessionProfileRef.current !== profileId) {
             sessionProfileRef.current = profileId;
+            setPreviousDay(null);
+            setLive({ active: false, profileId });
             try {
               const saved = JSON.parse(
                 window.localStorage.getItem(sessionStorageKey) || "null",
@@ -2492,18 +2504,25 @@ export default function Home() {
   }, [data, live]);
 
   useEffect(() => {
-    if (!data) return;
+    if (!data || history.profileId !== data.profileId) {
+      const frame = window.requestAnimationFrame(() => setPreviousDay(null));
+      return () => window.cancelAnimationFrame(frame);
+    }
     const previous = history.entries
       .filter((entry) => entry.dayIndex < data.dayIndex)
       .at(-1);
-    if (!previous) return;
+    if (!previous) {
+      const frame = window.requestAnimationFrame(() => setPreviousDay(null));
+      return () => window.cancelAnimationFrame(frame);
+    }
+    const expectedProfileId = data.profileId;
     fetch(`/data/days/${data.profileId || "default"}--${previous.dateKey}.json?save=${Date.now()}`, {
       cache: "no-store",
     })
       .then((response) => (response.ok ? response.json() : null))
       .then((snapshot) =>
         setPreviousDay(
-          snapshot
+          snapshot && snapshot.profileId === expectedProfileId
             ? localizeSnapshotGameNames(
                 { ...snapshot, seasonLabel: seasonName(snapshot.season) },
                 t,
@@ -2525,7 +2544,7 @@ export default function Home() {
 
   useEffect(() => {
     if (!data?.dailyBrief) return;
-    const storageKey = `stardew-tool-daily-brief-${data.farmName}`;
+    const storageKey = `stardew-tool-daily-brief-${data.profileId}`;
     if (window.localStorage.getItem(storageKey) !== data.dateKey) {
       const frame = window.requestAnimationFrame(() => {
         window.localStorage.setItem(storageKey, data.dateKey);
@@ -8949,7 +8968,7 @@ function SectionVisibilityMenu({
 
 function DailyBriefView({
   current,
-  previous,
+  previous: candidatePrevious,
   history,
   live,
   sessionBaseline,
@@ -8963,6 +8982,9 @@ function DailyBriefView({
   onOpenCommunityCenter: () => void;
 }) {
   const { t, text, date, locale } = useI18n();
+  const previous = candidatePrevious?.profileId === current.profileId
+    ? candidatePrevious
+    : null;
   const todaySectionOptions = [
     { id: "overview", label: t("today.section.overview") },
     { id: "priorities", label: t("today.section.priorities") },
@@ -10485,6 +10507,9 @@ function GrowthView({
   live: LiveState;
 }) {
   const { t, text, locale } = useI18n();
+  previousSnapshot = previousSnapshot?.profileId === current.profileId
+    ? previousSnapshot
+    : null;
   const growthSectionOptions = [
     { id: "metrics", label: t("growth.section.metrics") },
     { id: "milestones", label: t("growth.section.milestones") },
@@ -10499,7 +10524,7 @@ function GrowthView({
       "stardew-tool-visible-sections-growth-v1",
       growthSectionOptions.map((option) => option.id),
     );
-  const entries = history.entries;
+  const entries = history.profileId === current.profileId ? history.entries : [];
   const annotatedEntries = entries
     .filter((entry) => entry.annotations?.length)
     .slice(-12)

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -59,6 +59,7 @@ let gameWasRunning = false;
 let windowStateSaveTimer = null;
 let setupWindowStateSaveTimer = null;
 let farmSwitching = false;
+let manualFarmSelectionDuringGame = null;
 let resolvedSourcePython = null;
 let updateState = { status: "idle", currentVersion: app.getVersion() };
 const backendToken = randomBytes(32).toString("hex");
@@ -1299,12 +1300,13 @@ function isGameRunning() {
 function monitorGame() {
   setInterval(() => {
     const running = isGameRunning();
+    if (!running) manualFarmSelectionDuringGame = null;
     if (running && !gameWasRunning && validConfig(readConfig())) {
       startBackgroundTracking().catch((error) =>
         log(error?.stack || String(error)),
       );
     }
-    if (running && readConfig()?.autoFollowActiveSave !== false && !farmSwitching) {
+    if (running && !manualFarmSelectionDuringGame && readConfig()?.autoFollowActiveSave !== false && !farmSwitching) {
       const fresh = detectSaves().find(
         (save) => save.liveUpdatedAt && Date.now() - save.liveUpdatedAt < 9000,
       );
@@ -1416,9 +1418,18 @@ function installIpc() {
   });
   ipcMain.handle("farms:switch", async (event, incomingPath) => {
     requireDashboardSender(event);
-    return switchFarmConfig(incomingPath, (message) =>
-      event.sender.send("setup:progress", message),
-    );
+    const previousManualSelection = manualFarmSelectionDuringGame;
+    manualFarmSelectionDuringGame = isGameRunning()
+      ? resolve(String(incomingPath || ""))
+      : null;
+    try {
+      return await switchFarmConfig(incomingPath, (message) =>
+        event.sender.send("setup:progress", message),
+      );
+    } catch (error) {
+      manualFarmSelectionDuringGame = previousManualSelection;
+      throw error;
+    }
   });
   ipcMain.handle("settings:open", (event) => {
     requireDashboardSender(event);

--- a/scripts/dev-local.mjs
+++ b/scripts/dev-local.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, statSync, watch, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, statSync, watch, writeFileSync } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
 import { loadConfig, projectRoot, runtimeRoot, runtimePaths, validateConfig } from "./config.mjs";
 import { resolveLanguage } from "./localization.mjs";
@@ -24,6 +24,7 @@ const saveFile = config.savePath;
 const python = config.pythonCommand;
 const paths = runtimePaths(config);
 const liveDestination = resolve(runtimeRoot, "public/data/live-state.json");
+const activeProfileId = String(process.env.STARDEW_TOOL_PROFILE_ID || "default");
 const readerDirectory = resolve(runtimeRoot, ".cache/save-reader");
 const readerSave = resolve(readerDirectory, basename(saveFile));
 const gameSaveTemporary = `${saveFile}_STARDEWVALLEYSAVETMP`;
@@ -102,8 +103,12 @@ function copyLiveState() {
       ? `${liveSource}:${sourceStats.mtimeMs}:${sourceStats.size}`
       : "offline";
     if (fingerprint === copiedLiveFingerprint) return;
-    if (liveSource && existsSync(liveSource)) copyFileSync(liveSource, liveDestination);
-    else writeFileSync(liveDestination, JSON.stringify({ active: false }), "utf8");
+    if (liveSource && existsSync(liveSource)) {
+      const payload = JSON.parse(readFileSync(liveSource, "utf8"));
+      writeFileSync(liveDestination, JSON.stringify({ ...payload, profileId: activeProfileId }), "utf8");
+    } else {
+      writeFileSync(liveDestination, JSON.stringify({ active: false, profileId: activeProfileId }), "utf8");
+    }
     renderLocationMaps();
     syncRuntimePublic(["data/live-state.json", "data/farm-state.json", "assets/location-maps"]);
     copiedLiveFingerprint = fingerprint;

--- a/scripts/generate_snapshot.py
+++ b/scripts/generate_snapshot.py
@@ -2266,7 +2266,7 @@ def history_entry(snapshot: dict) -> dict:
 def update_history(snapshots: list[dict]) -> None:
     history_path = PROFILE_DATA / "farm-history.json"
     farm_name = snapshots[-1]["farmName"]
-    history = {"farmName": farm_name, "entries": []}
+    history = {"profileId": PROFILE_ID, "farmName": farm_name, "entries": []}
     season_labels = {"spring": "Spring", "summer": "Summer", "fall": "Fall", "winter": "Winter"}
     progress_defaults = {
         "farming": 0, "mining": 0, "foraging": 0, "fishing": 0, "combat": 0,
@@ -2303,12 +2303,20 @@ def update_history(snapshots: list[dict]) -> None:
             if checkpoint and checkpoint.get("farmName", farm_name) == farm_name:
                 add_entry(checkpoint)
 
-    history_sources = [history_path]
-    history_sources.extend(sorted(HISTORY_BACKUPS.glob("farm-history-*.json")) if HISTORY_BACKUPS.is_dir() else [])
-    history_sources.extend(root / "farm-history.json" for root in history_data_roots())
-    for source in history_sources:
+    profile_history_sources = [history_path]
+    profile_history_sources.extend(sorted(HISTORY_BACKUPS.glob("farm-history-*.json")) if HISTORY_BACKUPS.is_dir() else [])
+    legacy_history_sources = [root / "farm-history.json" for root in history_data_roots()]
+    for source, profile_scoped in [
+        *((item, True) for item in profile_history_sources),
+        *((item, False) for item in legacy_history_sources),
+    ]:
         recovered = read_json(source)
-        if not recovered or recovered.get("farmName", farm_name) != farm_name:
+        if (
+            not recovered
+            or recovered.get("farmName", farm_name) != farm_name
+            or (not profile_scoped and recovered.get("profileId") != PROFILE_ID)
+            or (recovered.get("profileId") not in {None, PROFILE_ID})
+        ):
             continue
         for entry in recovered.get("entries", []):
             add_entry(entry)
@@ -2316,12 +2324,18 @@ def update_history(snapshots: list[dict]) -> None:
     days_path = PROFILE_DATA / "days"
     days_path.mkdir(parents=True, exist_ok=True)
     for root in [PROFILE_DATA, *history_data_roots()]:
+        profile_scoped = root.resolve() == PROFILE_DATA.resolve()
         source_days = root / "days"
         if not source_days.is_dir():
             continue
         for snapshot_path in sorted(source_days.glob("*.json")):
             recovered_snapshot = read_json(snapshot_path)
-            if not recovered_snapshot or recovered_snapshot.get("farmName", farm_name) != farm_name:
+            if (
+                not recovered_snapshot
+                or recovered_snapshot.get("farmName", farm_name) != farm_name
+                or (not profile_scoped and recovered_snapshot.get("profileId") != PROFILE_ID)
+                or (recovered_snapshot.get("profileId") not in {None, PROFILE_ID})
+            ):
                 continue
             try:
                 add_entry(history_entry(recovered_snapshot))
@@ -2382,6 +2396,7 @@ def update_history(snapshots: list[dict]) -> None:
                     annotations.append(localized_message("history.annotation.friendshipHearts", friend=friend.get("name", "Friendship"), hearts=friend.get("points", 0) // 250))
             entry["annotations"] = annotations[:12]
         previous = entry
+    history["profileId"] = PROFILE_ID
     history["farmName"] = farm_name
     history["entries"] = entries
     atomic_write_json(history_path, history, backup=True)

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -670,6 +670,9 @@ test("farm history is checkpointed, backed up, and recovered across migrations",
   assert.match(generator, /source_days\.glob\("\*\.json"\)/);
   assert.match(generator, /destination = days_path \/ f'\{recovered_snapshot\["dateKey"\]\}\.json'/);
   assert.match(generator, /f'\{PROFILE_ID\}--\{snapshot\["dateKey"\]\}\.json'/);
+  assert.match(generator, /history = \{"profileId": PROFILE_ID, "farmName": farm_name/);
+  assert.match(generator, /recovered\.get\("profileId"\) != PROFILE_ID/);
+  assert.match(generator, /recovered_snapshot\.get\("profileId"\) != PROFILE_ID/);
   assert.match(generator, /checkpoint_root\.glob\("\*\.json\.bak"\)/);
   assert.match(desktop, /legacyDataDirs/);
   assert.match(desktop, /STARDEW_TOOL_LEGACY_DATA_DIRS/);
@@ -683,6 +686,26 @@ test("farm history is checkpointed, backed up, and recovered across migrations",
   assert.match(bridge, /farmName = player\.farmName\.Value/);
   assert.equal(JSON.parse(sourceManifest).Version, "5.1.0");
   assert.equal(JSON.parse(bundledManifest).Version, "5.1.0");
+});
+
+test("farm switching isolates previous-day, history, and LIVE state by profile", async () => {
+  const [page, desktop, localServer] = await Promise.all([
+    readFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../desktop/main.mjs", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/dev-local.mjs", import.meta.url), "utf8"),
+  ]);
+  assert.match(page, /type FarmHistory = \{ profileId: string;/);
+  assert.match(page, /if \(farmHistory\.profileId !== profileId\) return;/);
+  assert.match(page, /setPreviousDay\(null\);[\s\S]*setLive\(\{ active: false, profileId \}\);/);
+  assert.match(page, /history\.profileId !== data\.profileId/);
+  assert.match(page, /snapshot && snapshot\.profileId === expectedProfileId/);
+  assert.match(page, /candidatePrevious\?\.profileId === current\.profileId/);
+  assert.match(page, /payload\.profileId === expectedProfileId/);
+  assert.match(localServer, /JSON\.stringify\(\{ \.\.\.payload, profileId: activeProfileId \}\)/);
+  assert.match(desktop, /let manualFarmSelectionDuringGame = null;/);
+  assert.match(desktop, /if \(!running\) manualFarmSelectionDuringGame = null;/);
+  assert.match(desktop, /running && !manualFarmSelectionDuringGame && readConfig\(\)\?\.autoFollowActiveSave !== false/);
+  assert.match(desktop, /manualFarmSelectionDuringGame = isGameRunning\(\)/);
 });
 
 test("the SMAPI bridge stays invisible while exporting read-only LIVE state", async () => {


### PR DESCRIPTION
## Summary\n- scope generated history, recovered snapshots, previous-day comparisons, and LIVE payloads by the save profile ID\n- clear stale previous-farm state before Today or Progress can compare it\n- respect a manual farm selection for the rest of the current Stardew process, showing the selected farm offline when it differs from the running save\n- restore normal automatic LIVE following after Stardew closes\n- add regression coverage for cross-farm history and LIVE isolation\n\n## Safety\n- reads remain local and original saves remain untouched\n- no player identity, paths, saves, history, or game assets are committed\n\n## Validation\n- npm run verify:public\n- npm run lint\n- npm test (123 tests)\n\nCloses #69