### PR TITLE
fix(desktop): place loader on saved display

### DIFF
--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -357,6 +357,27 @@ function loadSetupWindowState() {
   return loadVisibleWindowState(setupWindowStatePath(), fallback, 720, 650);
 }
 
+function loadingWindowBounds() {
+  const width = 560;
+  const height = 430;
+  const saved = loadWindowState();
+  if (!Number.isFinite(saved.x) || !Number.isFinite(saved.y))
+    return { width, height };
+  const display = screen.getDisplayNearestPoint({
+    x: Math.round(saved.x + saved.width / 2),
+    y: Math.round(saved.y + saved.height / 2),
+  });
+  const area = display.workArea;
+  const centeredX = Math.round(saved.x + (saved.width - width) / 2);
+  const centeredY = Math.round(saved.y + (saved.height - height) / 2);
+  return {
+    width,
+    height,
+    x: Math.max(area.x, Math.min(centeredX, area.x + area.width - width)),
+    y: Math.max(area.y, Math.min(centeredY, area.y + area.height - height)),
+  };
+}
+
 function saveWindowState(window, path = windowStatePath()) {
   if (!window || window.isDestroyed()) return;
   const bounds = window.isMaximized()
@@ -1131,8 +1152,7 @@ function createLoadingWindow() {
   if (loadingWindow) return;
   loadingWindow = new BrowserWindow(
     secureWindowOptions({
-      width: 560,
-      height: 430,
+      ...loadingWindowBounds(),
       resizable: false,
       frame: false,
       webPreferences: { preload: join(projectRoot, "desktop", "preload.cjs") },

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1852,6 +1852,11 @@ test("desktop loading screen uses the complete original brand lockup and localiz
   assert.match(loadingScript, /messages\["loading\.title"\]/);
   assert.match(desktop, /t\("loading\.extractingAssets"\)/);
   assert.match(desktop, /t\("loading\.optimizing"\)/);
+  assert.match(desktop, /function loadingWindowBounds\(\)/);
+  assert.match(desktop, /const saved = loadWindowState\(\)/);
+  assert.match(desktop, /screen\.getDisplayNearestPoint\(/);
+  assert.match(desktop, /const area = display\.workArea/);
+  assert.match(desktop, /\.\.\.loadingWindowBounds\(\)/);
   assert.doesNotMatch(desktop, /progress\("Preparing your farmers/);
 });
 


### PR DESCRIPTION
## Summary\n- derive the loading window position from the dashboard's saved bounds\n- center the loader over the future dashboard position on the same monitor\n- clamp it to the selected display's work area\n- retain the existing safe fallback when the saved display is unavailable\n\n## Validation\n- npm run verify:public\n- npm run lint\n- npm test (123 tests)\n\nCloses #71