### PR TITLE
refactor(mods): show compatibility confidence only in context

### DIFF
--- a/app/compatibility.tsx
+++ b/app/compatibility.tsx
@@ -15,17 +15,29 @@ export type ModCompatibilitySummary = {
   parseFailureCount: number;
 };
 
-export function CompatibilityBadge({ summary }: { summary?: ModCompatibilitySummary }) {
+export function CompatibilityNotice({
+  summary,
+  domains,
+}: {
+  summary?: ModCompatibilitySummary;
+  domains: string[];
+}) {
   const { t } = useI18n();
-  if (!summary || summary.status === "vanilla") return null;
-  const uncertain = summary.status === "uncertain";
+  const uncertainDomains = (summary?.uncertainDomains || []).filter((domain) =>
+    domains.includes(domain),
+  );
+  if (!uncertainDomains.length) return null;
   return (
-    <span
-      className={`compatibility-badge ${uncertain ? "uncertain" : "mod-aware"}`}
-      title={t(uncertain ? "compatibility.uncertainDetail" : "compatibility.modAwareDetail")}
+    <p
+      className="compatibility-notice"
+      title={t("compatibility.uncertainDetail")}
     >
-      <span aria-hidden="true">{uncertain ? "!" : "✓"}</span>
-      <b>{t(uncertain ? "compatibility.uncertain" : "compatibility.modAware")}</b>
-    </span>
+      <span aria-hidden="true">!</span>
+      <span>{t("compatibility.contextual", {
+        domains: uncertainDomains
+          .map((domain) => t(`compatibility.domain.${domain}`))
+          .join(", "),
+      })}</span>
+    </p>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -306,46 +306,26 @@ button {
     sans-serif;
   color: #cbd7c7;
 }
-.compatibility-badge {
+.compatibility-notice {
   display: inline-flex;
   align-items: center;
-  flex: 0 0 auto;
-  gap: 5px;
-  padding: 5px 7px;
-  border: 1px solid #6f8b70;
-  color: #d8e7d3;
-  background: #2d4535;
-  font: 800 8px/1 Arial, sans-serif;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  white-space: nowrap;
+  gap: 7px;
+  margin: 8px 0 0;
+  padding: 6px 8px;
+  border-left: 2px solid #b77927;
+  color: #ead8ae;
+  background: rgb(183 121 39 / 12%);
+  font: 10px/1.35 Arial, sans-serif;
 }
-.compatibility-badge > span {
+.compatibility-notice > span:first-child {
   display: inline-grid;
   place-items: center;
+  flex: 0 0 auto;
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  background: #5c865f;
-}
-.compatibility-badge > b {
-  font: inherit;
-}
-.compatibility-badge.uncertain {
-  border-color: #c79a45;
   color: #fff0c7;
-  background: #5d4525;
-}
-.compatibility-badge.uncertain > span {
   background: #b77927;
-}
-.production-calculator .compatibility-badge {
-  margin-top: 7px;
-}
-@media (max-width: 1600px) {
-  .topbar > .compatibility-badge > b {
-    display: none;
-  }
 }
 .display-scale {
   display: flex;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "react";
 import packageMetadata from "../package.json";
 import { ChangelogHistory } from "./changelog";
-import { CompatibilityBadge, type ModCompatibilitySummary } from "./compatibility";
+import { type ModCompatibilitySummary } from "./compatibility";
 import { furnitureDestination } from "./furniture-layout.mjs";
 import { ProductionCalculator, type ProductionAnimal, type ProductionCatalog } from "./planning/production-calculator";
 import {
@@ -3619,7 +3619,6 @@ export default function Home() {
             {t("nav.progress")} <kbd>6</kbd>
           </button>
         </nav>
-        <CompatibilityBadge summary={data.modCompatibility} />
         <button
           className={`save-note ${live.active ? "is-live" : ""}`}
           onMouseEnter={openLivePanel}

--- a/app/planning/production-calculator.tsx
+++ b/app/planning/production-calculator.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { useI18n } from "../i18n";
-import { CompatibilityBadge, type ModCompatibilitySummary } from "../compatibility";
+import { CompatibilityNotice, type ModCompatibilitySummary } from "../compatibility";
 import {
   STARDEW_SEASONS,
   addStardewDays,
@@ -442,6 +442,15 @@ export function ProductionCalculator({
   const animalProcessors = (catalog?.artisanMachines || []).filter(conversion => animalInputIds.has(conversion.input.id));
   const animalProcessorConversion = animalProcessors.find(conversion => conversion.id === animalProcessorId);
   const pondProcessorConversion = (catalog?.artisanMachines || []).find(conversion => conversion.machine.name === "Preserves Jar");
+  const compatibilityDomains = selectedIsAnimal
+    ? ["animals", "items", "buildings", ...(animalProcessorConversion ? ["machines"] : [])]
+    : selectedIsPond
+      ? ["fish", "items", "buildings", ...(pondProcessRoe ? ["machines"] : [])]
+      : selectedIsMachine
+        ? ["machines", "items", "recipes", "other"]
+        : selectedIsForestry
+          ? ["crops", "items", "other"]
+          : ["crops", "items", "other"];
   const selectedNamed = namedEntries.find(({ entry }) => entry.id === selected?.id);
   const calculation = useMemo<Omit<SavedCalculation, "id">>(() => ({
     selectedId: selected?.id || "",
@@ -970,7 +979,6 @@ export function ProductionCalculator({
           <p className="eyebrow">{t("planner.quick.eyebrow")}</p>
           <h2 id="production-calculator-title">{t("planner.quick.title")}</h2>
           <p>{t("planner.quick.description")}</p>
-          <CompatibilityBadge summary={modCompatibility} />
         </div>
       </div>
       {!entries.length ? (
@@ -1286,6 +1294,7 @@ export function ProductionCalculator({
             </ul>}
             {selectedIsForestry && <ul className="planner-warnings"><li>{t(selected.kind === "mushroom-log" ? "forestry.logUncertainty" : !forestryExisting ? "forestry.treeUncertainty" : "forestry.tapAssumptions")}</li></ul>}
             {selected.kind === "crop" && selectedFertilizer && !selectedFertilizer.verifiedCost && <ul className="planner-warnings"><li>{t("planner.warning.fertilizer-cost-unknown", { fertilizer: fertilizerName(selectedFertilizer) })}</li></ul>}
+            <CompatibilityNotice summary={modCompatibility} domains={compatibilityDomains} />
           </div>}
           <div className="planner-bookmark-toolbar">
             <input type="text" value={bookmarkName} onChange={(event) => setBookmarkName(event.target.value)} placeholder={t("planner.bookmark.namePlaceholder")} aria-label={t("planner.bookmark.name")} />

--- a/locales/en.json
+++ b/locales/en.json
@@ -1820,6 +1820,7 @@
   "compatibility.modAwareDetail": "Companion detected supported local content-pack changes and incorporated the domains it understands.",
   "compatibility.uncertain": "Mod compatibility uncertain",
   "compatibility.uncertainDetail": "Installed mods may alter rules that Companion cannot verify. Review assumptions before relying on recommendations.",
+  "compatibility.contextual": "Some values in this result use modded rules that Companion cannot verify: {domains}.",
   "compatibility.modsDetected": "Installed mods",
   "compatibility.contentPacks": "Content packs",
   "compatibility.unclassifiedMods": "Unverified code mods",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1820,6 +1820,7 @@
   "compatibility.modAwareDetail": "Companion ha detectado cambios compatibles de paquetes locales y ha incorporado los dominios que comprende.",
   "compatibility.uncertain": "Compatibilidad con mods incierta",
   "compatibility.uncertainDetail": "Los mods instalados pueden modificar reglas que Companion no puede verificar. Revisa las suposiciones antes de confiar en las recomendaciones.",
+  "compatibility.contextual": "Algunos valores de este resultado usan reglas modificadas que Companion no puede verificar: {domains}.",
   "compatibility.modsDetected": "Mods instalados",
   "compatibility.contentPacks": "Paquetes de contenido",
   "compatibility.unclassifiedMods": "Mods de código sin verificar",

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1133,9 +1133,11 @@ test("the desktop refreshes extracted NPC assets after a mod changes", async () 
   assert.match(desktop, /extractedAssetsAreStale\(config, requiredAssets\)/);
 });
 
-test("mod compatibility is explicit and copied diagnostics exclude farm identity", async () => {
-  const [page, desktop, scanner, snapshot] = await Promise.all([
+test("mod compatibility is contextual and copied diagnostics exclude farm identity", async () => {
+  const [page, calculator, compatibility, desktop, scanner, snapshot] = await Promise.all([
     readFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../app/planning/production-calculator.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../app/compatibility.tsx", import.meta.url), "utf8"),
     readFile(new URL("../desktop/main.mjs", import.meta.url), "utf8"),
     readFile(new URL("../scripts/mod-compatibility.mjs", import.meta.url), "utf8"),
     readFile(new URL("../scripts/generate_snapshot.py", import.meta.url), "utf8"),
@@ -1144,7 +1146,13 @@ test("mod compatibility is explicit and copied diagnostics exclude farm identity
   assert.match(scanner, /uncertainDomains/);
   assert.match(scanner, /SAFE_CODE_MODS/);
   assert.match(snapshot, /"modCompatibility": game_data\.get/);
-  assert.match(page, /<CompatibilityBadge summary=\{data\.modCompatibility\}/);
+  assert.doesNotMatch(page, /<CompatibilityBadge summary=\{data\.modCompatibility\}/);
+  assert.doesNotMatch(page, /<CompatibilityNotice/);
+  assert.match(calculator, /<CompatibilityNotice summary=\{modCompatibility\} domains=\{compatibilityDomains\}/);
+  assert.match(calculator, /selectedIsAnimal[\s\S]*?\["animals", "items", "buildings"/);
+  assert.match(calculator, /selectedIsPond[\s\S]*?\["fish", "items", "buildings"/);
+  assert.match(compatibility, /summary\?\.uncertainDomains/);
+  assert.match(compatibility, /domains\.includes\(domain\)/);
   assert.match(page, /modCompatibility: diagnostics\.modCompatibility/);
   assert.doesNotMatch(page, /JSON\.stringify\(\{ \.\.\.diagnostics/);
   assert.doesNotMatch(desktop, /profileId: profileIdForSave\(config\?\.savePath\)/);


### PR DESCRIPTION
## Summary\n- remove the global mod-compatibility badge from the application header\n- keep complete compatibility information in Help diagnostics\n- show a quiet contextual note only when a calculator result depends on an uncertain game-data domain\n- map crop, forestry, machine, animal, and pond calculations to their actual data dependencies\n- localize the contextual explanation and list only the affected domains\n\n## Validation\n- npm run verify:public\n- npm run verify:localization\n- npm run lint\n- npm test (123 tests)\n\nContributes to #14