### PR TITLE
feat(mods): apply safe Content Patcher crop data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ yarn-error.log*
 /assetbuild/unpacked/*
 /assetbuild/storage-location-maps/
 /assetbuild/game-data.json
+/assetbuild/content-patcher-catalog.json
 !/public/assets/.gitkeep
 !/assetbuild/unpacked/.gitkeep
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -8140,6 +8140,12 @@ button {
     700 12px Arial,
     sans-serif;
 }
+.modded-item-fallback {
+  display: none;
+}
+.modded-item-artwork.missing .modded-item-fallback {
+  display: block;
+}
 .animal-artwork {
   position: relative;
   flex: 0 0 40px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5292,6 +5292,19 @@ function SheetArtwork({
   );
 }
 
+function ModdedItemArtwork({ url, label, spriteIndex = 0, columns = 1 }: { url: string; label: string; spriteIndex?: number; columns?: number }) {
+  const scale = 2;
+  return <span className="sheet-artwork object modded-item-artwork" title={label} aria-hidden="true">
+    <span className="modded-item-fallback">{label.slice(0, 1)}</span>
+    {/* Content Patcher artwork is copied from the local installation at runtime. */}
+    {/* eslint-disable-next-line @next/next/no-img-element */}
+    <img src={url} alt="" style={{ left: -(spriteIndex % columns) * 16 * scale, top: -Math.floor(spriteIndex / columns) * 16 * scale }} onError={(event) => {
+      event.currentTarget.hidden = true;
+      event.currentTarget.closest(".sheet-artwork")?.classList.add("missing");
+    }} />
+  </span>;
+}
+
 function AnimalArtwork({ animal, label }: { animal: ProductionAnimal; label: string }) {
   const width = Math.max(1, Number(animal.spriteWidth) || 16);
   const height = Math.max(1, Number(animal.spriteHeight) || 16);
@@ -7737,7 +7750,9 @@ function PlanningView({
             currentPonds={current.planningBrief.fishPonds}
             profileId={current.profileId || `${current.farmName}-${current.farmer}`}
             resolveGameName={gameName}
-            renderItemArtwork={(id, name, spriteIndex) => <SheetArtwork id={String(spriteIndex ?? id.replace(/^\((?:O|BC)\)/, ""))} kind={id.startsWith("(BC)") ? "craftable" : "object"} label={name} fit />}
+            renderItemArtwork={(id, name, spriteIndex, artworkUrl, artworkColumns) => artworkUrl
+              ? <ModdedItemArtwork url={artworkUrl} label={name} spriteIndex={spriteIndex} columns={artworkColumns} />
+              : <SheetArtwork id={String(spriteIndex ?? id.replace(/^\((?:O|BC)\)/, ""))} kind={id.startsWith("(BC)") ? "craftable" : "object"} label={name} fit />}
             renderAnimalArtwork={(animal) => <AnimalArtwork animal={animal} label={gameName(animal.name)} />}
             modCompatibility={current.modCompatibility}
           />

--- a/app/planning/production-calculator.tsx
+++ b/app/planning/production-calculator.tsx
@@ -19,8 +19,9 @@ import { calculateAnimalPlan } from "./animal-engine.mjs";
 import { calculateFishPondPlan } from "./pond-engine.mjs";
 import { evaluateProductionPortfolio } from "./portfolio-engine.mjs";
 
+type ProductionItem = { id: string; name: string; price: number; category?: number; spriteIndex?: number; artworkUrl?: string; artworkColumns?: number };
 export type ProductionCatalogEntry = Omit<ProductionProducer, "outputValue"> & {
-  output: { id: string; name: string; price: number; category?: number; spriteIndex?: number };
+  output: ProductionItem;
   growthPhases?: number[];
   yieldRules?: { maxIncreasePerFarmingLevel: number; extraHarvestChance: number };
   clearance?: number;
@@ -352,7 +353,7 @@ export function ProductionCalculator({
   currentPonds?: Array<{ fishId: string; population: number; capacity: number }>;
   profileId: string;
   resolveGameName: (name: string, id?: string) => string;
-  renderItemArtwork?: (id: string, name: string, spriteIndex?: number) => ReactNode;
+  renderItemArtwork?: (id: string, name: string, spriteIndex?: number, artworkUrl?: string, artworkColumns?: number) => ReactNode;
   renderAnimalArtwork?: (animal: ProductionAnimal) => ReactNode;
   modCompatibility?: ModCompatibilitySummary;
 }) {
@@ -969,7 +970,7 @@ export function ProductionCalculator({
   const producerArtwork = (entry: ProductionCatalogEntry, outputName: string, machineInput = false) => {
     if (entry.animal && renderAnimalArtwork) return renderAnimalArtwork(entry.animal);
     if (machineInput && entry.machineConversion) return renderItemArtwork?.(entry.machineConversion.input.id, resolveGameName(entry.machineConversion.input.name, entry.machineConversion.input.id), entry.machineConversion.input.spriteIndex);
-    return renderItemArtwork?.(entry.output.id, outputName, entry.output.spriteIndex);
+    return renderItemArtwork?.(entry.output.id, outputName, entry.output.spriteIndex, entry.output.artworkUrl, entry.output.artworkColumns);
   };
 
   return (

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -433,7 +433,7 @@ function extractedAssetsAreStale(config, requiredAssets) {
   if (!existsSync(gameData)) return true;
   const extracted = readJson(gameData, {});
   if (
-    extracted?._localization?.catalogVersion !== 9
+    extracted?._localization?.catalogVersion !== 10
   )
     return true;
   return (

--- a/scripts/content-patcher-catalog.mjs
+++ b/scripts/content-patcher-catalog.mjs
@@ -1,0 +1,106 @@
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+
+import JSON5 from "json5";
+
+const MAX_DEPTH = 8;
+
+async function readJson5(path) {
+  return JSON5.parse(await readFile(path, "utf8"));
+}
+
+async function manifestPaths(root, depth = 0) {
+  if (!root || depth > 4) return [];
+  const found = [];
+  try {
+    for (const entry of await readdir(root, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith(".")) continue;
+      const directory = join(root, entry.name);
+      const manifest = join(directory, "manifest.json");
+      if (existsSync(manifest)) found.push(manifest);
+      else found.push(...await manifestPaths(directory, depth + 1));
+    }
+  } catch {
+    // A missing or unreadable Mods directory is equivalent to no overlays.
+  }
+  return found;
+}
+
+function plainEntries(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return Object.values(value).every((entry) => entry && typeof entry === "object" && !Array.isArray(entry)) ? value : null;
+}
+
+function hasRuntimeTokens(value) {
+  return /\{\{/.test(JSON.stringify(value));
+}
+
+function targets(value) {
+  return (Array.isArray(value) ? value : String(value || "").split(","))
+    .map((entry) => String(entry).trim().replace(/\\/g, "/").toLowerCase())
+    .filter(Boolean);
+}
+
+function filePaths(value) {
+  return (Array.isArray(value) ? value : String(value || "").split(","))
+    .map((entry) => String(entry).trim())
+    .filter(Boolean);
+}
+
+function supportedDataEdit(change, target) {
+  if (String(change?.Action || "").toLowerCase() !== "editdata" || change.When || change.Fields || change.MoveEntries)
+    return false;
+  const entries = plainEntries(change.Entries);
+  if (!entries || hasRuntimeTokens(entries)) return false;
+  const targetField = Array.isArray(change.TargetField) ? change.TargetField.map(String) : [];
+  if (target === "data/objects" || target === "data/crops") return targetField.length === 0;
+  return target === "data/shops" && targetField.length === 2 && targetField[1].toLowerCase() === "items";
+}
+
+function addEdit(overlay, change, target) {
+  if (!supportedDataEdit(change, target)) return false;
+  if (target === "data/objects") Object.assign(overlay.objects, change.Entries);
+  else if (target === "data/crops") Object.assign(overlay.crops, change.Entries);
+  else {
+    overlay.shopItems.push({
+      shopId: String(change.TargetField[0]),
+      items: Object.entries(change.Entries).map(([id, item]) => ({ ...item, Id: item.Id || id })),
+    });
+  }
+  return true;
+}
+
+async function inspectContentFile(path, packRoot, overlay, visited, depth = 0) {
+  const resolved = resolve(path);
+  if (depth > MAX_DEPTH || relative(packRoot, resolved).startsWith("..") || visited.has(resolved)) return;
+  visited.add(resolved);
+  const content = await readJson5(resolved);
+  for (const change of Array.isArray(content.Changes) ? content.Changes : []) {
+    const action = String(change?.Action || "").toLowerCase();
+    if (action === "include" && !change.When && !hasRuntimeTokens(change.FromFile)) {
+      for (const include of filePaths(change.FromFile))
+        await inspectContentFile(resolve(dirname(resolved), include), packRoot, overlay, visited, depth + 1);
+      continue;
+    }
+    for (const target of targets(change?.Target)) addEdit(overlay, change, target);
+  }
+}
+
+export async function buildContentPatcherCatalogOverlay(modsRoot) {
+  const overlay = { objects: {}, crops: {}, shopItems: [] };
+  for (const manifestPath of await manifestPaths(modsRoot)) {
+    try {
+      const manifest = await readJson5(manifestPath);
+      if (String(manifest?.ContentPackFor?.UniqueID || "").toLowerCase() !== "pathoschild.contentpatcher") continue;
+      const packRoot = dirname(manifestPath);
+      const contentPath = join(packRoot, "content.json");
+      if (existsSync(contentPath)) await inspectContentFile(contentPath, packRoot, overlay, new Set());
+    } catch {
+      // Compatibility diagnostics report unreadable packs; extraction stays usable.
+    }
+  }
+  return overlay;
+}
+
+export { supportedDataEdit };

--- a/scripts/content-patcher-catalog.mjs
+++ b/scripts/content-patcher-catalog.mjs
@@ -58,6 +58,15 @@ function supportedDataEdit(change, target) {
   return target === "data/shops" && targetField.length === 2 && targetField[1].toLowerCase() === "items";
 }
 
+function supportedAssetLoad(change, target) {
+  return String(change?.Action || "").toLowerCase() === "load" &&
+    !change.When &&
+    /^mods\//i.test(target) &&
+    typeof change.FromFile === "string" &&
+    !hasRuntimeTokens(change.FromFile) &&
+    /\.png$/i.test(change.FromFile);
+}
+
 function addEdit(overlay, change, target) {
   if (!supportedDataEdit(change, target)) return false;
   if (target === "data/objects") Object.assign(overlay.objects, change.Entries);
@@ -83,12 +92,17 @@ async function inspectContentFile(path, packRoot, overlay, visited, depth = 0) {
         await inspectContentFile(resolve(dirname(resolved), include), packRoot, overlay, visited, depth + 1);
       continue;
     }
-    for (const target of targets(change?.Target)) addEdit(overlay, change, target);
+    for (const target of targets(change?.Target)) {
+      if (supportedAssetLoad(change, target)) {
+        const source = resolve(packRoot, change.FromFile);
+        if (!relative(packRoot, source).startsWith("..")) overlay.textures[target] = source;
+      } else addEdit(overlay, change, target);
+    }
   }
 }
 
 export async function buildContentPatcherCatalogOverlay(modsRoot) {
-  const overlay = { objects: {}, crops: {}, shopItems: [] };
+  const overlay = { objects: {}, crops: {}, shopItems: [], textures: {} };
   for (const manifestPath of await manifestPaths(modsRoot)) {
     try {
       const manifest = await readJson5(manifestPath);
@@ -103,4 +117,4 @@ export async function buildContentPatcherCatalogOverlay(modsRoot) {
   return overlay;
 }
 
-export { supportedDataEdit };
+export { supportedAssetLoad, supportedDataEdit };

--- a/scripts/extract_game_data.mjs
+++ b/scripts/extract_game_data.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { extname, resolve } from "node:path";
@@ -17,6 +18,7 @@ if (errors.length) throw new Error(errors.join(" "));
 const project = runtimeRoot;
 const { contentRoot, modsRoot } = runtimePaths(config);
 const modCompatibility = scanModCompatibility(modsRoot);
+const contentPatcherOverlay = await buildContentPatcherCatalogOverlay(modsRoot);
 ensureRuntimeDirectories();
 
 async function unpack(relativePath) {
@@ -98,7 +100,7 @@ async function extractProductionCatalog() {
     throw new Error("The local game data extractor is missing. Run npm run desktop:game-data.");
   const overlayPath = resolve(project, "assetbuild/content-patcher-catalog.json");
   await mkdir(resolve(overlayPath, ".."), { recursive: true });
-  await writeFile(overlayPath, JSON.stringify(await buildContentPatcherCatalogOverlay(modsRoot)), "utf8");
+  await writeFile(overlayPath, JSON.stringify(contentPatcherOverlay), "utf8");
   const result = spawnSync(executable, [config.stardewPath, overlayPath], {
     cwd: projectRoot,
     encoding: "utf8",
@@ -111,6 +113,30 @@ async function extractProductionCatalog() {
   return JSON.parse(result.stdout);
 }
 const productionCatalog = await extractProductionCatalog();
+async function attachContentPatcherArtwork(catalog, overlay) {
+  const artwork = new Map();
+  for (const [target, source] of Object.entries(overlay.textures || {})) {
+    try {
+      const image = await readFile(source);
+      if (image.length < 24 || image.toString("ascii", 1, 4) !== "PNG") continue;
+      const width = image.readUInt32BE(16);
+      const name = `${createHash("sha256").update(target).digest("hex").slice(0, 20)}.png`;
+      const destination = resolve(project, "public/assets/mod-items", name);
+      await mkdir(resolve(destination, ".."), { recursive: true });
+      await copyFile(source, destination);
+      artwork.set(target.toLowerCase(), { artworkUrl: `/assets/mod-items/${name}`, artworkColumns: Math.max(1, Math.floor(width / 16)) });
+    } catch {
+      // Missing optional textures retain the generated placeholder.
+    }
+  }
+  const visit = (value) => {
+    if (!value || typeof value !== "object") return;
+    if (typeof value.texture === "string") Object.assign(value, artwork.get(value.texture.replace(/\\/g, "/").toLowerCase()) || {});
+    for (const child of Array.isArray(value) ? value : Object.values(value)) visit(child);
+  };
+  visit(catalog);
+}
+await attachContentPatcherArtwork(productionCatalog, contentPatcherOverlay);
 for (const [domain, skipped] of Object.entries(productionCatalog.overlayDiagnostics?.skipped || {})) {
   if (!skipped) continue;
   modCompatibility.status = "uncertain";

--- a/scripts/extract_game_data.mjs
+++ b/scripts/extract_game_data.mjs
@@ -154,7 +154,7 @@ async function buildGameLocalizationCatalog(catalogLanguage, catalogLocale, cata
   return {
     language: catalogLanguage,
     locale: catalogLocale,
-    catalogVersion: 9,
+    catalogVersion: 10,
     objectNames,
     localizedObjectNamesByEnglish,
     localizedNamesByQualifiedId,
@@ -178,7 +178,7 @@ const gameLocalizationCatalogs = Object.fromEntries(
 const activeLocalization = gameLocalizationCatalogs.en;
 
 const gameData = {
-  _localization: { language: "neutral", catalogVersion: 9 },
+  _localization: { language: "neutral", catalogVersion: 10 },
   modCompatibility,
   giftTastes: await unpack("Data/NPCGiftTastes.xnb"),
   cookingRecipes: await unpack("Data/CookingRecipes.xnb"),

--- a/scripts/extract_game_data.mjs
+++ b/scripts/extract_game_data.mjs
@@ -9,6 +9,7 @@ import { ensureRuntimeDirectories, syncRuntimePublic } from "./runtime-files.mjs
 import { renderCommunityRooms } from "./render-community-rooms.mjs";
 import { localizedXnbPath } from "./localization.mjs";
 import { scanModCompatibility } from "./mod-compatibility.mjs";
+import { buildContentPatcherCatalogOverlay } from "./content-patcher-catalog.mjs";
 
 const config = loadConfig();
 const errors = validateConfig(config, { requireSave: false });
@@ -91,11 +92,14 @@ const nameCatalogs = [
   ["Strings/FarmAnimals.xnb", key => key.includes("DisplayType_")],
 ];
 const fish = await unpack("Data/Fish.xnb");
-function extractProductionCatalog() {
+async function extractProductionCatalog() {
   const executable = resolve(projectRoot, "desktop", "resources", "game-data-extractor", "StardewDataExtractor.exe");
   if (!existsSync(executable))
     throw new Error("The local game data extractor is missing. Run npm run desktop:game-data.");
-  const result = spawnSync(executable, [config.stardewPath], {
+  const overlayPath = resolve(project, "assetbuild/content-patcher-catalog.json");
+  await mkdir(resolve(overlayPath, ".."), { recursive: true });
+  await writeFile(overlayPath, JSON.stringify(await buildContentPatcherCatalogOverlay(modsRoot)), "utf8");
+  const result = spawnSync(executable, [config.stardewPath, overlayPath], {
     cwd: projectRoot,
     encoding: "utf8",
     windowsHide: true,
@@ -106,7 +110,12 @@ function extractProductionCatalog() {
     throw new Error(`The local game data extractor exited with code ${result.status}: ${result.stderr || "unknown error"}`);
   return JSON.parse(result.stdout);
 }
-const productionCatalog = extractProductionCatalog();
+const productionCatalog = await extractProductionCatalog();
+for (const [domain, skipped] of Object.entries(productionCatalog.overlayDiagnostics?.skipped || {})) {
+  if (!skipped) continue;
+  modCompatibility.status = "uncertain";
+  modCompatibility.uncertainDomains = [...new Set([...modCompatibility.uncertainDomains, domain])];
+}
 async function buildGameLocalizationCatalog(catalogLanguage, catalogLocale, catalogSuffix) {
   const localizedObjectNamesByEnglish = Object.assign(
     {},
@@ -322,7 +331,9 @@ async function readJson5(path, fallback = {}) {
 }
 
 function conditionMatches(when, configValues) {
-  return Object.entries(when || {}).every(([key, expected]) => !(key in configValues) || String(configValues[key]).toLowerCase() === String(expected).toLowerCase());
+  return Object.entries(when || {}).every(([key, expected]) =>
+    key in configValues && String(configValues[key]).toLowerCase() === String(expected).toLowerCase(),
+  );
 }
 
 function resolveTokens(value, tokens) {

--- a/scripts/mod-compatibility.mjs
+++ b/scripts/mod-compatibility.mjs
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 
 import JSON5 from "json5";
+import { supportedDataEdit } from "./content-patcher-catalog.mjs";
 
 const SAFE_CODE_MODS = new Set([
   "maglucen.stardewvalleytoolbridge",
@@ -9,13 +10,14 @@ const SAFE_CODE_MODS = new Set([
   "pathoschild.contentpatcher",
   "smapi.savebackup",
 ]);
-const SUPPORTED_CONTENT_PACK_DOMAINS = new Set(["npcs"]);
+const SUPPORTED_CONTENT_PACK_DOMAINS = new Set(["items", "crops", "npcs"]);
 const DOMAIN_ORDER = ["items", "crops", "fish", "recipes", "machines", "animals", "npcs", "buildings", "locations", "maps", "quests", "other"];
 
 function domainForTarget(target) {
   const normalized = String(target || "").replace(/\\/g, "/").toLowerCase();
   if (!normalized || normalized.includes("{{")) return "other";
   if (/^data\/(objects|bigcraftables|furniture|hats|shirts|pants|boots)/.test(normalized)) return "items";
+  if (/^data\/shops/.test(normalized)) return "items";
   if (/^data\/(crops|wildtrees|fruittrees)/.test(normalized)) return "crops";
   if (/^data\/(fish|fishponddata)/.test(normalized)) return "fish";
   if (/^data\/(cookingrecipes|craftingrecipes)/.test(normalized)) return "recipes";
@@ -29,11 +31,14 @@ function domainForTarget(target) {
   return "other";
 }
 
-function supportedContentChange(action, target) {
+function supportedContentChange(change, target) {
+  const action = String(change?.Action || "").toLowerCase();
   const normalized = String(target || "").replace(/\\/g, "/").toLowerCase();
+  if (supportedDataEdit(change, normalized)) return true;
   return (
+    !change?.When &&
     (action === "editdata" && ["data/characters", "data/npcgifttastes"].includes(normalized)) ||
-    (action === "load" && /^(characters|portraits)\/[^/]+$/.test(normalized))
+    (!change?.When && action === "load" && /^(characters|portraits)\/[^/]+$/.test(normalized))
   );
 }
 
@@ -101,7 +106,7 @@ function inspectContentFile(path, packRoot, state, visited, depth = 0) {
     for (const target of targets) {
       const domain = domainForTarget(target);
       state.alteredDomains.add(domain);
-      if (domain === "other" || !SUPPORTED_CONTENT_PACK_DOMAINS.has(domain) || !supportedContentChange(action, target))
+      if (domain === "other" || !SUPPORTED_CONTENT_PACK_DOMAINS.has(domain) || !supportedContentChange(change, target))
         state.uncertainDomains.add(domain);
       else
         state.supportedDomains.add(domain);

--- a/scripts/mod-compatibility.mjs
+++ b/scripts/mod-compatibility.mjs
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 
 import JSON5 from "json5";
-import { supportedDataEdit } from "./content-patcher-catalog.mjs";
+import { supportedAssetLoad, supportedDataEdit } from "./content-patcher-catalog.mjs";
 
 const SAFE_CODE_MODS = new Set([
   "maglucen.stardewvalleytoolbridge",
@@ -104,6 +104,7 @@ function inspectContentFile(path, packRoot, state, visited, depth = 0) {
       continue;
     }
     for (const target of targets) {
+      if (supportedAssetLoad(change, target)) continue;
       const domain = domainForTarget(target);
       state.alteredDomains.add(domain);
       if (domain === "other" || !SUPPORTED_CONTENT_PACK_DOMAINS.has(domain) || !supportedContentChange(change, target))

--- a/tests/mod-compatibility.test.mjs
+++ b/tests/mod-compatibility.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import test from "node:test";
 
 import { scanModCompatibility } from "../scripts/mod-compatibility.mjs";
+import { buildContentPatcherCatalogOverlay } from "../scripts/content-patcher-catalog.mjs";
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), "companion-mods-"));
@@ -52,19 +53,44 @@ test("supported Content Patcher NPC data is identified as mod-aware", () => {
   }
 });
 
-test("unverified crop edits and code mods produce explicit uncertainty", () => {
+test("supported local crop, object, and shop additions are catalog-aware", async () => {
+  const files = fixture();
+  try {
+    files.addMod("Crop Pack", {
+      UniqueID: "Example.Crops",
+      ContentPackFor: { UniqueID: "Pathoschild.ContentPatcher" },
+    }, { Changes: [
+      { Action: "EditData", Target: "Data/Objects", Entries: { "Example.Seed": { Name: "Example Seed", Price: 10 } } },
+      { Action: "EditData", Target: "Data/Crops", Entries: { "Example.Seed": { Seasons: ["Spring"], DaysInPhase: [1], HarvestItemId: "Example.Fruit" } } },
+      { Action: "EditData", Target: "Data/Shops", TargetField: ["SeedShop", "Items"], Entries: { Example: { Id: "Example", ItemId: "Example.Seed", Price: 25 } } },
+    ] });
+    const summary = scanModCompatibility(files.root);
+    assert.equal(summary.status, "mod-aware");
+    assert.deepEqual(summary.supportedDomains, ["items", "crops"]);
+    assert.deepEqual(summary.uncertainDomains, []);
+    const overlay = await buildContentPatcherCatalogOverlay(files.root);
+    assert.equal(overlay.objects["Example.Seed"].Name, "Example Seed");
+    assert.equal(overlay.crops["Example.Seed"].HarvestItemId, "Example.Fruit");
+    assert.deepEqual(overlay.shopItems, [{ shopId: "SeedShop", items: [{ Id: "Example", ItemId: "Example.Seed", Price: 25 }] }]);
+  } finally {
+    files.cleanup();
+  }
+});
+
+test("conditional or tokenized crop edits and code mods produce explicit uncertainty", async () => {
   const files = fixture();
   try {
     files.addMod("Crop Pack", {
       UniqueID: "PrivateName.NeverExported",
       ContentPackFor: { UniqueID: "Pathoschild.ContentPatcher" },
-    }, { Changes: [{ Action: "EditData", Target: "Data/Crops", Entries: {} }] });
+    }, { Changes: [{ Action: "EditData", Target: "Data/Crops", When: { Season: "spring" }, Entries: { "{{Token}}": {} } }] });
     files.addMod("Gameplay Mod", { UniqueID: "Example.Gameplay", Version: "2.0.0" });
     const summary = scanModCompatibility(files.root);
     assert.equal(summary.status, "uncertain");
     assert.deepEqual(summary.alteredDomains, ["crops"]);
     assert.deepEqual(summary.uncertainDomains, ["crops", "other"]);
     assert.equal(summary.unclassifiedCodeModCount, 1);
+    assert.deepEqual((await buildContentPatcherCatalogOverlay(files.root)).crops, {});
     assert.doesNotMatch(JSON.stringify(summary), /PrivateName|Gameplay Mod|companion-mods/i);
   } finally {
     files.cleanup();

--- a/tests/mod-compatibility.test.mjs
+++ b/tests/mod-compatibility.test.mjs
@@ -14,6 +14,7 @@ function fixture() {
     mkdirSync(target, { recursive: true });
     writeFileSync(join(target, "manifest.json"), JSON.stringify(manifest), "utf8");
     if (content) writeFileSync(join(target, "content.json"), JSON.stringify(content), "utf8");
+    return target;
   };
   return { root, addMod, cleanup: () => rmSync(root, { recursive: true, force: true }) };
 }
@@ -56,14 +57,16 @@ test("supported Content Patcher NPC data is identified as mod-aware", () => {
 test("supported local crop, object, and shop additions are catalog-aware", async () => {
   const files = fixture();
   try {
-    files.addMod("Crop Pack", {
+    const pack = files.addMod("Crop Pack", {
       UniqueID: "Example.Crops",
       ContentPackFor: { UniqueID: "Pathoschild.ContentPatcher" },
     }, { Changes: [
       { Action: "EditData", Target: "Data/Objects", Entries: { "Example.Seed": { Name: "Example Seed", Price: 10 } } },
       { Action: "EditData", Target: "Data/Crops", Entries: { "Example.Seed": { Seasons: ["Spring"], DaysInPhase: [1], HarvestItemId: "Example.Fruit" } } },
       { Action: "EditData", Target: "Data/Shops", TargetField: ["SeedShop", "Items"], Entries: { Example: { Id: "Example", ItemId: "Example.Seed", Price: 25 } } },
+      { Action: "Load", Target: "Mods/Example.Crops/Fruit", FromFile: "fruit.png" },
     ] });
+    writeFileSync(join(pack, "fruit.png"), Buffer.from("not-a-committed-game-asset"));
     const summary = scanModCompatibility(files.root);
     assert.equal(summary.status, "mod-aware");
     assert.deepEqual(summary.supportedDomains, ["items", "crops"]);
@@ -72,6 +75,7 @@ test("supported local crop, object, and shop additions are catalog-aware", async
     assert.equal(overlay.objects["Example.Seed"].Name, "Example Seed");
     assert.equal(overlay.crops["Example.Seed"].HarvestItemId, "Example.Fruit");
     assert.deepEqual(overlay.shopItems, [{ shopId: "SeedShop", items: [{ Id: "Example", ItemId: "Example.Seed", Price: 25 }] }]);
+    assert.equal(overlay.textures["mods/example.crops/fruit"], join(pack, "fruit.png"));
   } finally {
     files.cleanup();
   }

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -2091,7 +2091,8 @@ test("production planner works offline with a catalog derived from the local gam
   assert.match(calculator, /acceleratedGrowthDays/);
   assert.match(calculator, /tillerApplies/);
   assert.match(calculator, /entry\.kind === "crop"[\s\S]*resolveGameName\(entry\.output\.name, entry\.output\.id\)/);
-  assert.match(calculator, /renderItemArtwork\?\.\(entry\.output\.id, outputName, entry\.output\.spriteIndex\)/);
+  assert.match(calculator, /renderItemArtwork\?\.\(entry\.output\.id, outputName, entry\.output\.spriteIndex, entry\.output\.artworkUrl, entry\.output\.artworkColumns\)/);
+  assert.match(page, /function ModdedItemArtwork/);
   assert.match(calculator, /className="planner-result-identity"/);
   assert.match(calculator, /className="planner-comparison-identity"/);
   assert.match(calculator, /className="planner-producer-menu"/);
@@ -2131,7 +2132,9 @@ test("production planner works offline with a catalog derived from the local gam
   assert.match(calculator, /!selectedIsForestry \|\| !forestryExisting/);
   assert.match(calculator, /resetCalculation/);
   assert.match(calculator, /forcePlantToday/);
-  assert.match(page, /renderItemArtwork=\{.{0,160}<SheetArtwork/);
+  assert.match(page, /renderItemArtwork=\{/);
+  assert.match(page, /<ModdedItemArtwork/);
+  assert.match(page, /: <SheetArtwork/);
   assert.match(extractor, /StardewDataExtractor\.exe/);
   assert.match(gameReader, /Data\/Crops/);
   assert.match(gameReader, /Data\/Objects/);

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1662,8 +1662,8 @@ test("Farm, Plan, and Progress share storage, goals, history, and completion dat
   assert.match(extractor, /Strings\/Furniture\.xnb/);
   assert.match(extractor, /Data\/Boots\.xnb/);
   assert.match(extractor, /Data\/hats\.xnb/);
-  assert.match(extractor, /catalogVersion: 9/);
-  assert.match(desktop, /catalogVersion !== 9/);
+  assert.match(extractor, /catalogVersion: 10/);
+  assert.match(desktop, /catalogVersion !== 10/);
   assert.match(extractor, /game-localization\.\$\{catalogLanguage\}\.json/);
   assert.match(extractor, /const activeLocalization = gameLocalizationCatalogs\.en/);
   assert.match(extractor, /Data\/Achievements\.xnb/);

--- a/tools/StardewDataExtractor/Program.cs
+++ b/tools/StardewDataExtractor/Program.cs
@@ -115,10 +115,7 @@ static class GameCatalogReader
         {
             string qualifiedId = QualifyObject(id);
             ObjectData? data = ObjectFor(qualifiedId);
-            int? spriteIndex = data?.Texture?.StartsWith("Mods/", StringComparison.OrdinalIgnoreCase) == true
-                ? null
-                : data?.SpriteIndex;
-            return new { id = qualifiedId, name = data?.Name ?? qualifiedId, price = data?.Price ?? 0, category = data?.Category, spriteIndex };
+            return new { id = qualifiedId, name = data?.Name ?? qualifiedId, price = data?.Price ?? 0, category = data?.Category, spriteIndex = data?.SpriteIndex, texture = data?.Texture };
         }
         object[] RecipeMaterials(string name)
         {

--- a/tools/StardewDataExtractor/Program.cs
+++ b/tools/StardewDataExtractor/Program.cs
@@ -115,7 +115,10 @@ static class GameCatalogReader
         {
             string qualifiedId = QualifyObject(id);
             ObjectData? data = ObjectFor(qualifiedId);
-            return new { id = qualifiedId, name = data?.Name ?? qualifiedId, price = data?.Price ?? 0, category = data?.Category, spriteIndex = data?.SpriteIndex };
+            int? spriteIndex = data?.Texture?.StartsWith("Mods/", StringComparison.OrdinalIgnoreCase) == true
+                ? null
+                : data?.SpriteIndex;
+            return new { id = qualifiedId, name = data?.Name ?? qualifiedId, price = data?.Price ?? 0, category = data?.Category, spriteIndex };
         }
         object[] RecipeMaterials(string name)
         {

--- a/tools/StardewDataExtractor/Program.cs
+++ b/tools/StardewDataExtractor/Program.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Xna.Framework.Content;
 using StardewValley.GameData.BigCraftables;
 using StardewValley.GameData.Buildings;
@@ -15,8 +16,8 @@ using StardewValley.GameData.Shops;
 using StardewValley.GameData.WildTrees;
 using GameObject = StardewValley.Object;
 
-if (args.Length != 1)
-    throw new ArgumentException("Expected the local Stardew Valley installation directory.");
+if (args.Length is < 1 or > 2)
+    throw new ArgumentException("Expected the local Stardew Valley installation directory and an optional local data overlay.");
 
 string gameRoot = Path.GetFullPath(args[0]);
 AssemblyLoadContext.Default.Resolving += (_, assemblyName) =>
@@ -25,7 +26,7 @@ AssemblyLoadContext.Default.Resolving += (_, assemblyName) =>
     return File.Exists(candidate) ? AssemblyLoadContext.Default.LoadFromAssemblyPath(candidate) : null;
 };
 
-Console.Write(GameCatalogReader.Read(Path.Combine(gameRoot, "Content")));
+Console.Write(GameCatalogReader.Read(Path.Combine(gameRoot, "Content"), args.Length > 1 ? args[1] : null));
 
 static class GameCatalogReader
 {
@@ -33,7 +34,7 @@ static class GameCatalogReader
     private const int FruitTreeClearanceTiles = 9;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static string Read(string contentRoot)
+    public static string Read(string contentRoot, string? overlayPath)
     {
         using var content = new ContentManager(new EmptyServices(), contentRoot);
         Dictionary<string, CropData> crops = content.Load<Dictionary<string, CropData>>("Data/Crops");
@@ -47,6 +48,39 @@ static class GameCatalogReader
         Dictionary<string, BigCraftableData> bigCraftables = content.Load<Dictionary<string, BigCraftableData>>("Data/BigCraftables");
         Dictionary<string, BuildingData> buildings = content.Load<Dictionary<string, BuildingData>>("Data/Buildings");
         Dictionary<string, string> craftingRecipes = content.Load<Dictionary<string, string>>("Data/CraftingRecipes");
+        int skippedObjectEdits = 0;
+        int skippedCropEdits = 0;
+        int skippedShopEdits = 0;
+
+        if (!string.IsNullOrWhiteSpace(overlayPath) && File.Exists(overlayPath))
+        {
+            var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, IncludeFields = true };
+            jsonOptions.Converters.Add(new JsonStringEnumConverter());
+            CatalogOverlay? overlay = JsonSerializer.Deserialize<CatalogOverlay>(File.ReadAllText(overlayPath), jsonOptions);
+            foreach ((string id, JsonElement entry) in overlay?.Objects ?? new())
+            {
+                if (objects.ContainsKey(id)) { skippedObjectEdits += 1; continue; }
+                ObjectData? value = entry.Deserialize<ObjectData>(jsonOptions);
+                if (value is not null) objects[id] = value;
+            }
+            foreach ((string id, JsonElement entry) in overlay?.Crops ?? new())
+            {
+                if (crops.ContainsKey(id)) { skippedCropEdits += 1; continue; }
+                CropData? value = entry.Deserialize<CropData>(jsonOptions);
+                if (value is not null) crops[id] = value;
+            }
+            foreach (ShopItemOverlay addition in overlay?.ShopItems ?? new())
+            {
+                if (!shops.TryGetValue(addition.ShopId, out ShopData? shop)) continue;
+                foreach (JsonElement entry in addition.Items)
+                {
+                    ShopItemData? value = entry.Deserialize<ShopItemData>(jsonOptions);
+                    if (value is null) continue;
+                    if (shop.Items.Any(item => item.Id == value.Id)) { skippedShopEdits += 1; continue; }
+                    shop.Items.Add(value);
+                }
+            }
+        }
 
         static string QualifyObject(string? id) => string.IsNullOrWhiteSpace(id) ? "" : id.StartsWith('(') ? id : $"(O){id}";
         static string Unqualify(string? id)
@@ -450,7 +484,7 @@ static class GameCatalogReader
             .ToArray();
 
         return JsonSerializer.Serialize(
-            new { catalogVersion = 6, source = "local-game", crops = cropCatalog, fruitTrees = treeCatalog, fertilizers = fertilizerCatalog, tappedTrees = tappedTreeCatalog, mushroomLogs = mushroomLogRules, mushroomLogOutputs, forestryEquipment, artisanMachines, farmAnimals = animalCatalog, fishPonds = pondCatalog, feedUnitCost = PurchasePrice("(O)178") },
+            new { catalogVersion = 6, source = "local-game", crops = cropCatalog, fruitTrees = treeCatalog, fertilizers = fertilizerCatalog, tappedTrees = tappedTreeCatalog, mushroomLogs = mushroomLogRules, mushroomLogOutputs, forestryEquipment, artisanMachines, farmAnimals = animalCatalog, fishPonds = pondCatalog, feedUnitCost = PurchasePrice("(O)178"), overlayDiagnostics = new { skipped = new { items = skippedObjectEdits + skippedShopEdits, crops = skippedCropEdits } } },
             new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }
         );
     }
@@ -458,5 +492,18 @@ static class GameCatalogReader
     private sealed class EmptyServices : IServiceProvider
     {
         public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class CatalogOverlay
+    {
+        public Dictionary<string, JsonElement> Objects { get; set; } = new();
+        public Dictionary<string, JsonElement> Crops { get; set; } = new();
+        public List<ShopItemOverlay> ShopItems { get; set; } = new();
+    }
+
+    private sealed class ShopItemOverlay
+    {
+        public string ShopId { get; set; } = "";
+        public List<JsonElement> Items { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- apply unconditional Content Patcher additions for Data/Objects and Data/Crops before building the production catalog
- import matching SeedShop item additions so modded seed costs remain accurate
- reject conditional, tokenized, partial, conflicting, or replacement edits as uncertain instead of inventing results
- keep the local overlay ignored and add synthetic compatibility tests

## Local validation
- real installed content pack: 2/2 added crops reached the catalog with seasons, growth phases, harvest prices, and shop prices; both verified
- npm run desktop:game-data
- npm run lint
- npm run verify:public
- npm test (124 passing before final conservative conflict guard; focused suite re-run after it)

Part of #14