### PR TITLE
feat(routes): add contextual delivery and fishing stops

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ import packageMetadata from "../package.json";
 import { ChangelogHistory } from "./changelog";
 import { type ModCompatibilitySummary } from "./compatibility";
 import { furnitureDestination } from "./furniture-layout.mjs";
-import { estimateRouteMinutes, normalizeRouteProfile, orderRouteStops, ROUTE_PROFILES, type RouteProfile } from "./route-planner.mjs";
+import { estimateRouteMinutes, fishingQuestRouteStop, normalizeRouteProfile, orderRouteStops, ROUTE_PROFILES, type RouteProfile } from "./route-planner.mjs";
 import { ProductionCalculator, type ProductionAnimal, type ProductionCatalog } from "./planning/production-calculator";
 import {
   useI18n,
@@ -9221,6 +9221,35 @@ function DailyBriefView({
       })),
     ]),
   );
+  const bundleDeliveries = liveReadyBundleDeliveries(
+    current.planningBrief.communityCenter,
+    live,
+  );
+  const liveInventoryCounts = new Map<string, number>();
+  for (const item of live.inventory || []) {
+    const id = inventoryItemId(item);
+    liveInventoryCounts.set(id, (liveInventoryCounts.get(id) || 0) + item.count);
+  }
+  const routeBundleDeliveries = live.active
+    ? bundleDeliveries.filter((item) => (liveInventoryCounts.get(normalizeObjectId(item.id)) || 0) >= item.count)
+    : bundleDeliveries;
+  const routeQuestCandidates = live.active
+    ? live.acceptedQuests || []
+    : [brief.dailyQuest, ...(brief.acceptedQuests || [])];
+  const routeFishingQuest = routeQuestCandidates.find((quest) =>
+    quest.type.toLocaleLowerCase("en-US").includes("fishing") &&
+    (quest.progress || 0) < (quest.target || 1),
+  );
+  const routeFish = routeFishingQuest
+    ? current.fishingBrief.fish.find((fish) =>
+        fish.id === String(routeFishingQuest.requestedId || "").replace(/^\(O\)/, "") ||
+        fish.name === routeFishingQuest.requestedName)
+    : undefined;
+  const fishingRouteOpportunity = fishingQuestRouteStop(routeFish, {
+    season: live.active ? live.season || current.season : current.season,
+    weather: live.active ? (live.raining ? "rainy" : "sunny") : current.fishingBrief.weather,
+    time: live.active ? live.timeOfDay || 600 : 600,
+  });
   const routeSource = brief.world
     .filter((stop) => stop.location !== "Farm Cave")
     .map((stop) => ({ ...stop, items: [...stop.items] }));
@@ -9249,6 +9278,10 @@ function DailyBriefView({
     !routeSource.some((stop) => stop.location === "Town")
   )
     routeSource.push({ location: "Town", items: [] });
+  if (routeBundleDeliveries.length && !routeSource.some((stop) => stop.location === "Town"))
+    routeSource.push({ location: "Town", items: [] });
+  if (fishingRouteOpportunity && !routeSource.some((stop) => stop.location === fishingRouteOpportunity.location))
+    routeSource.push({ location: fishingRouteOpportunity.location, items: [] });
   const routeAccess = brief.routeContext?.access || {};
   const unavailableRouteStops = routeSource.filter(
     (stop) => routeAccess[stop.location] === false,
@@ -9319,6 +9352,8 @@ function DailyBriefView({
         notes.push(t("today.route.machinesReady", { count: readyMachinesCount }));
     }
     if (location === "Town") {
+      if (routeBundleDeliveries.length)
+        notes.push(t("today.route.bundleDeliveries", { count: routeBundleDeliveries.length }));
       if ((live.active ? liveBoardQuest : brief.boardQuest)?.available)
         notes.push(t("today.route.helpWantedAvailable"));
       if (activeDailyQuest.accepted) notes.push(t("today.route.helpWantedAccepted"));
@@ -9331,6 +9366,17 @@ function DailyBriefView({
             : t("today.route.toolWaiting", { tool: brief.toolUpgrade.displayName || brief.toolUpgrade.name }),
         );
     }
+    if (location === fishingRouteOpportunity?.location && routeFish)
+      notes.push(t("today.route.fishingQuestWindow", {
+        fish: routeFish.displayName || resolveGameDisplayName(
+          current.localizedNamesByQualifiedId || {},
+          current.localizedObjectNamesByEnglish || {},
+          routeFish.name,
+          `(O)${routeFish.id}`,
+        ),
+        start: fishTime(fishingRouteOpportunity.start),
+        end: fishTime(fishingRouteOpportunity.end),
+      }));
     return notes;
   };
   const displayedQuest = live.active
@@ -9426,10 +9472,6 @@ function DailyBriefView({
           (sum, crop) => sum + Math.max(0, crop.count - crop.watered),
           0,
         );
-  const bundleDeliveries = liveReadyBundleDeliveries(
-    current.planningBrief.communityCenter,
-    live,
-  );
   const bundleDeliveryDetail = bundleDeliveries
     .map(
       (item) => `${formatBundleRequirement(item, t, locale)} → ${communityRoomName(item.roomId, t)} · ${communityBundleName(item.bundleId, item.bundle, t)}`,

--- a/app/route-planner.d.mts
+++ b/app/route-planner.d.mts
@@ -9,3 +9,12 @@ export function estimateRouteMinutes(
   transport?: { horse?: boolean; minecarts?: boolean },
   profile?: RouteProfile,
 ): number;
+export function fishingQuestRouteStop(
+  fish: {
+    seasons: string[];
+    weather: string;
+    windows: number[][];
+    accessibleLocations: string[];
+  } | undefined,
+  context: { season?: string; weather?: string; time?: number },
+): { location: string; start: number; end: number } | null;

--- a/app/route-planner.mjs
+++ b/app/route-planner.mjs
@@ -35,3 +35,25 @@ export function estimateRouteMinutes(stopCount, { horse = false, minecarts = fal
   const adjusted = base * (horse ? 0.8 : 1) * (minecarts ? 0.9 : 1);
   return Math.max(20, Math.round(adjusted / 10) * 10);
 }
+
+const FISHING_ROUTE_LOCATIONS = [
+  [/ocean|beach/i, "Beach"],
+  [/mountain|lake|mine/i, "Mountain"],
+  [/forest|cindersap/i, "Cindersap Forest"],
+  [/town|river/i, "Town"],
+  [/secret woods/i, "Secret Woods"],
+  [/desert/i, "Desert"],
+  [/ginger|island/i, "Ginger Island"],
+];
+
+export function fishingQuestRouteStop(fish, { season, weather, time = 600 } = {}) {
+  if (!fish || !fish.seasons?.includes(season)) return null;
+  if (fish.weather && fish.weather !== "both" && fish.weather !== weather) return null;
+  const futureWindow = (fish.windows || []).find(([, end]) => end > time);
+  if (!futureWindow) return null;
+  for (const rawLocation of fish.accessibleLocations || []) {
+    const match = FISHING_ROUTE_LOCATIONS.find(([pattern]) => pattern.test(rawLocation));
+    if (match) return { location: match[1], start: Math.max(time, futureWindow[0]), end: futureWindow[1] };
+  }
+  return null;
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -406,6 +406,8 @@
   "today.route.profile.mining.detail": "Prioritizes the mountain, railroad, and desert side of the route.",
   "today.route.profile.relaxed": "Relaxed",
   "today.route.profile.relaxed.detail": "Keeps every task but uses a more generous pace estimate.",
+  "today.route.bundleDeliveries": "{count} bundle deliveries ready",
+  "today.route.fishingQuestWindow": "Catch {fish} for the active request · {start}–{end}",
   "today.priority.waterCrops": "Water {count} crops",
   "today.priority.gettingLate": "It is getting late; do it before sleeping.",
   "today.priority.needWater": "They will not grow tonight without water.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -406,6 +406,8 @@
   "today.route.profile.mining.detail": "Prioriza la montaña, el ferrocarril y la zona del desierto.",
   "today.route.profile.relaxed": "Relajada",
   "today.route.profile.relaxed.detail": "Mantiene todas las tareas, pero calcula un ritmo más holgado.",
+  "today.route.bundleDeliveries": "{count} entregas de lotes listas",
+  "today.route.fishingQuestWindow": "Captura {fish} para el encargo activo · {start}–{end}",
   "today.priority.waterCrops": "Riega {count} cultivos",
   "today.priority.gettingLate": "Se está haciendo tarde; hazlo antes de dormir.",
   "today.priority.needWater": "No crecerán esta noche si no los riegas.",

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -906,6 +906,10 @@ test("route checks distinguish manual decisions from reversible LIVE completion"
   assert.match(page, /today\.route\.inaccessibleSkipped/);
   assert.match(page, /today\.route\.unknownAccess/);
   assert.match(page, /today\.route\.roughEstimate/);
+  assert.match(page, /fishingQuestRouteStop/);
+  assert.match(page, /routeBundleDeliveries/);
+  assert.match(page, /today\.route\.fishingQuestWindow/);
+  assert.match(page, /today\.route\.bundleDeliveries/);
   assert.match(styles, /\.route-assumptions/);
   assert.match(styles, /\.route-access-warning/);
 });

--- a/tests/route-planner.test.mjs
+++ b/tests/route-planner.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { estimateRouteMinutes, normalizeRouteProfile, orderRouteStops } from "../app/route-planner.mjs";
+import { estimateRouteMinutes, fishingQuestRouteStop, normalizeRouteProfile, orderRouteStops } from "../app/route-planner.mjs";
 
 const stops = ["Beach", "Town", "Farm", "Mountain", "Custom Lagoon"].map(location => ({ location }));
 
@@ -20,4 +20,11 @@ test("route estimates expose transport savings and a slower relaxed pace", () =>
   const walking = estimateRouteMinutes(5);
   assert.ok(estimateRouteMinutes(5, { horse: true, minecarts: true }) < walking);
   assert.ok(estimateRouteMinutes(5, {}, "relaxed") > walking);
+});
+
+test("fishing quests become stops only while the requested fish is available", () => {
+  const fish = { seasons: ["summer"], weather: "sunny", windows: [[600, 1200]], accessibleLocations: ["Ocean"] };
+  assert.deepEqual(fishingQuestRouteStop(fish, { season: "summer", weather: "sunny", time: 900 }), { location: "Beach", start: 900, end: 1200 });
+  assert.equal(fishingQuestRouteStop(fish, { season: "summer", weather: "rainy", time: 900 }), null);
+  assert.equal(fishingQuestRouteStop(fish, { season: "summer", weather: "sunny", time: 1300 }), null);
 });


### PR DESCRIPTION
## Summary
- add a Town stop when bundle deliveries are ready; in LIVE require the items to be in the backpack
- add an active fishing-request stop only when the requested fish matches the current season, weather, access, and remaining time window
- show the fish and exact available window in the route explanation
- map fishing areas to route locations while safely skipping unsupported locations
- add focused route-engine tests

## Verification
- npm run lint
- npm test (128 passed)
- npm run verify:public

Continues #13.