### PR TITLE
feat(mods): support local modded fishing data

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -327,6 +327,20 @@ button {
   color: #fff0c7;
   background: #b77927;
 }
+
+.mod-rule-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.1rem 0.3rem;
+  border: 1px solid currentColor;
+  color: var(--gold);
+  font-family: var(--font-sans);
+  font-size: 0.58rem;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
 .display-scale {
   display: flex;
   align-items: center;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -340,6 +340,11 @@ type FishingFish = {
   basePrice: number;
   minFishingLevel: number;
   caught: boolean;
+  modded?: boolean;
+  verified?: boolean;
+  spriteIndex?: number;
+  artworkUrl?: string;
+  artworkColumns?: number;
 };
 type DisplayFishingFish = FishingFish & { displayName: string };
 type FishingBrief = {
@@ -5945,6 +5950,9 @@ function FishingView({
     } as Record<string, string>)[name];
     return key ? t(`fishing.location.${key}`) : name;
   };
+  const fishArtwork = (fish: FishingFish, label: string) => fish.artworkUrl
+    ? <ModdedItemArtwork url={fish.artworkUrl} label={label} spriteIndex={fish.spriteIndex} columns={fish.artworkColumns} />
+    : <SheetArtwork id={fish.id} kind="object" label={label} />;
   const [hour, setHour] = useState(600);
   const [useLiveTime, setUseLiveTime] = useState(true);
   const [fishListMode, setFishListMode] = useState<"collection" | "all">(() =>
@@ -6231,6 +6239,11 @@ function FishingView({
                           : t("fishing.weather.sunny")}
                     </span>
                     <span>{t("fishing.difficulty", { difficulty: fish.difficulty })}</span>
+                    {fish.modded && !fish.verified && (
+                      <span className="mod-rule-badge" title={t("fishing.modRuleDetail")}>
+                        {t("fishing.modRuleUnverified")}
+                      </span>
+                    )}
                     {atLiveLocation(fish) && (
                       <span className="current-area-chip">
                         {t("fishing.availableHere")}
@@ -6299,11 +6312,7 @@ function FishingView({
                     className={`fish-row ${fish.caught ? "caught" : "missing"} ${mission ? "mission-fish" : ""} ${here ? "current-location-fish" : ""}`}
                     key={fish.id}
                   >
-                    <SheetArtwork
-                      id={fish.id}
-                      kind="object"
-                      label={fish.displayName}
-                    />
+                    {fishArtwork(fish, fish.displayName)}
                     <div>
                       <strong>
                         {fish.displayName}
@@ -6311,6 +6320,11 @@ function FishingView({
                         {here && <em className="here-badge">{t("fishing.here")}</em>}
                         {fishListMode === "all" && fish.caught && (
                           <em className="caught-badge">{t("fishing.caught")}</em>
+                        )}
+                        {fish.modded && !fish.verified && (
+                          <em className="mod-rule-badge" title={t("fishing.modRuleDetail")}>
+                            {t("fishing.modRuleUnverified")}
+                          </em>
                         )}
                       </strong>
                       <small>{fish.accessibleLocations.map(locationName).join(" · ")}</small>
@@ -6341,7 +6355,7 @@ function FishingView({
                   className={questForFish(fish) ? "mission-fish" : ""}
                   key={fish.id}
                 >
-                  <SheetArtwork id={fish.id} kind="object" label={fish.displayName} />
+                  {fishArtwork(fish, fish.displayName)}
                   <b>{fish.displayName}</b>
                   {questForFish(fish) && <em>{t("fishing.mission")}</em>} · {fishWindow(fish)}{" "}
                   · {locationName(fish.accessibleLocations[0])}

--- a/locales/en.json
+++ b/locales/en.json
@@ -182,6 +182,8 @@
   "fishing.mission": "MISSION",
   "fishing.here": "HERE",
   "fishing.caught": "CAUGHT",
+  "fishing.modRuleUnverified": "MOD RULE",
+  "fishing.modRuleDetail": "This fish comes from a mod with availability conditions Companion cannot fully verify.",
   "fishing.wiki": "Wiki",
   "fishing.noneMissingNow": "No available fish are missing at this time in this weather. Change the time to plan the rest of the day.",
   "fishing.noneAvailableNow": "No fish are available at this time in this weather.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -182,6 +182,8 @@
   "fishing.mission": "ENCARGO",
   "fishing.here": "AQUÍ",
   "fishing.caught": "CAPTURADO",
+  "fishing.modRuleUnverified": "REGLA DE MOD",
+  "fishing.modRuleDetail": "Este pez procede de un mod con condiciones de disponibilidad que Companion no puede verificar por completo.",
   "fishing.wiki": "Wiki",
   "fishing.noneMissingNow": "No te falta ningún pez disponible a esta hora y con este tiempo. Cambia la hora para planificar el resto del día.",
   "fishing.noneAvailableNow": "No hay peces disponibles a esta hora y con este tiempo.",

--- a/scripts/content-patcher-catalog.mjs
+++ b/scripts/content-patcher-catalog.mjs
@@ -32,6 +32,11 @@ function plainEntries(value) {
   return Object.values(value).every((entry) => entry && typeof entry === "object" && !Array.isArray(entry)) ? value : null;
 }
 
+function stringEntries(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return Object.values(value).every((entry) => typeof entry === "string") ? value : null;
+}
+
 function hasRuntimeTokens(value) {
   return /\{\{/.test(JSON.stringify(value));
 }
@@ -51,10 +56,17 @@ function filePaths(value) {
 function supportedDataEdit(change, target) {
   if (String(change?.Action || "").toLowerCase() !== "editdata" || change.When || change.Fields || change.MoveEntries)
     return false;
-  const entries = plainEntries(change.Entries);
+  const entries = plainEntries(change.Entries) || stringEntries(change.Entries);
   if (!entries || hasRuntimeTokens(entries)) return false;
   const targetField = Array.isArray(change.TargetField) ? change.TargetField.map(String) : [];
-  if (target === "data/objects" || target === "data/crops") return targetField.length === 0;
+  if (["data/objects", "data/crops", "data/buildings"].includes(target))
+    return targetField.length === 0 && plainEntries(entries) !== null;
+  if (target === "data/locations" && targetField.length === 0)
+    return plainEntries(entries) !== null;
+  if (["data/fish", "data/cookingrecipes", "data/craftingrecipes"].includes(target))
+    return targetField.length === 0 && stringEntries(entries) !== null;
+  if (target === "data/locations")
+    return targetField.length === 2 && targetField[1].toLowerCase() === "fish" && plainEntries(entries) !== null;
   return target === "data/shops" && targetField.length === 2 && targetField[1].toLowerCase() === "items";
 }
 
@@ -71,6 +83,17 @@ function addEdit(overlay, change, target) {
   if (!supportedDataEdit(change, target)) return false;
   if (target === "data/objects") Object.assign(overlay.objects, change.Entries);
   else if (target === "data/crops") Object.assign(overlay.crops, change.Entries);
+  else if (target === "data/fish") Object.assign(overlay.fish, change.Entries);
+  else if (target === "data/cookingrecipes") Object.assign(overlay.cookingRecipes, change.Entries);
+  else if (target === "data/craftingrecipes") Object.assign(overlay.craftingRecipes, change.Entries);
+  else if (target === "data/buildings") Object.assign(overlay.buildings, change.Entries);
+  else if (target === "data/locations" && !change.TargetField?.length) Object.assign(overlay.locations, change.Entries);
+  else if (target === "data/locations") {
+    overlay.locationFish.push({
+      locationId: String(change.TargetField[0]),
+      items: Object.entries(change.Entries).map(([id, item]) => ({ ...item, Id: item.Id || id })),
+    });
+  }
   else {
     overlay.shopItems.push({
       shopId: String(change.TargetField[0]),
@@ -102,7 +125,10 @@ async function inspectContentFile(path, packRoot, overlay, visited, depth = 0) {
 }
 
 export async function buildContentPatcherCatalogOverlay(modsRoot) {
-  const overlay = { objects: {}, crops: {}, shopItems: [], textures: {} };
+  const overlay = {
+    objects: {}, crops: {}, fish: {}, cookingRecipes: {}, craftingRecipes: {},
+    buildings: {}, locations: {}, locationFish: [], shopItems: [], textures: {},
+  };
   for (const manifestPath of await manifestPaths(modsRoot)) {
     try {
       const manifest = await readJson5(manifestPath);

--- a/scripts/extract_game_data.mjs
+++ b/scripts/extract_game_data.mjs
@@ -94,7 +94,16 @@ const nameCatalogs = [
   ["Strings/FarmAnimals.xnb", key => key.includes("DisplayType_")],
 ];
 const fish = await unpack("Data/Fish.xnb");
+const cookingRecipes = await unpack("Data/CookingRecipes.xnb");
+const craftingRecipes = await unpack("Data/CraftingRecipes.xnb");
 const festivalDates = await unpack("Data/Festivals/FestivalDates.xnb");
+function addMissingEntries(target, additions) {
+  for (const [id, entry] of Object.entries(additions || {}))
+    if (!(id in target)) target[id] = entry;
+}
+addMissingEntries(fish, contentPatcherOverlay.fish);
+addMissingEntries(cookingRecipes, contentPatcherOverlay.cookingRecipes);
+addMissingEntries(craftingRecipes, contentPatcherOverlay.craftingRecipes);
 async function extractProductionCatalog() {
   const executable = resolve(projectRoot, "desktop", "resources", "game-data-extractor", "StardewDataExtractor.exe");
   if (!existsSync(executable))
@@ -208,8 +217,8 @@ const gameData = {
   _localization: { language: "neutral", catalogVersion: 11 },
   modCompatibility,
   giftTastes: await unpack("Data/NPCGiftTastes.xnb"),
-  cookingRecipes: await unpack("Data/CookingRecipes.xnb"),
-  craftingRecipes: await unpack("Data/CraftingRecipes.xnb"),
+  cookingRecipes,
+  craftingRecipes,
   cookingChannel: await unpack("Data/TV/CookingChannel.xnb"),
   tipChannel: await unpack("Data/TV/TipChannel.xnb"),
   fish,

--- a/scripts/generate_snapshot.py
+++ b/scripts/generate_snapshot.py
@@ -1551,8 +1551,14 @@ def fishing_brief(root: ET.Element, player: ET.Element, season: str, day: int, p
     try:
         game_data = json.loads(GAME_DATA.read_text(encoding="utf-8"))
         raw_fish = game_data.get("fish", {})
+        catalog_fish = {
+            unqualified_item_id(item.get("id", "")): item
+            for item in game_data.get("productionCatalog", {}).get("fishing", [])
+            if isinstance(item, dict) and item.get("id")
+        }
     except (OSError, json.JSONDecodeError):
         raw_fish = {}
+        catalog_fish = {}
 
     caught = {
         (item.findtext("key/string") or "").removeprefix("(O)")
@@ -1564,6 +1570,30 @@ def fishing_brief(root: ET.Element, player: ET.Element, season: str, day: int, p
     desert_open = any(key in mail for key in ("ccVault", "jojaVault", "ccVaultFin"))
     ginger_open = "willyBoatFixed" in mail
     legendary_levels = {"159": 5, "160": 3, "163": 10, "775": 6}
+    location_nodes = root.find("locations")
+    saved_locations = {
+        location.findtext("name", "")
+        for location in (location_nodes if location_nodes is not None else [])
+    }
+
+    def catalog_location(entry: dict) -> str:
+        location_id = str(entry.get("id") or "")
+        area_id = str(entry.get("fishAreaId") or "")
+        known = {
+            "Beach": "Ocean", "Town": "Town River", "Mountain": "Mountain Lake",
+            "Woods": "Secret Woods", "Sewer": "Sewers", "Desert": "Desert",
+            "WitchSwamp": "Witch's Swamp", "BugLand": "Mutant Bug Lair",
+            "IslandSouth": "Ginger Island Ocean", "IslandSouthEast": "Ginger Island Ocean",
+            "IslandSouthEastCave": "Ginger Island · Pirate Cove",
+            "IslandWest": "Ginger Island River/Pond" if area_id != "Ocean" else "Ginger Island Ocean",
+            "Forest": "Forest Pond" if area_id.lower() == "pond" else "Forest River",
+        }
+        if location_id in known:
+            return known[location_id]
+        display_name = str(entry.get("displayName") or "")
+        if display_name and not display_name.startswith("[") and "{{" not in display_name:
+            return display_name
+        return location_id
 
     def accessible_location(location: str) -> bool:
         if location.startswith("The Mines"):
@@ -1579,25 +1609,53 @@ def fishing_brief(root: ET.Element, player: ET.Element, season: str, day: int, p
 
     fish = []
     for fish_id, raw in raw_fish.items():
-        if fish_id not in FISH_LOCATIONS or not isinstance(raw, str):
+        if not isinstance(raw, str):
             continue
         parts = raw.split("/")
         if len(parts) < 9 or not parts[1].isdigit():
             continue
+        catalog_entry = catalog_fish.get(unqualified_item_id(fish_id), {})
         times_raw = [int(value) for value in parts[5].split() if value.isdigit()]
-        windows = [[times_raw[index], times_raw[index + 1]] for index in range(0, len(times_raw) - 1, 2)]
-        locations = FISH_LOCATIONS[fish_id]
+        windows = catalog_entry.get("windows") or [
+            [times_raw[index], times_raw[index + 1]]
+            for index in range(0, len(times_raw) - 1, 2)
+        ]
+        catalog_locations = catalog_entry.get("locations") or []
+        locations = FISH_LOCATIONS.get(fish_id) or list(dict.fromkeys(
+            catalog_location(entry) for entry in catalog_locations if catalog_location(entry)
+        ))
+        if not locations:
+            continue
         accessible = [location for location in locations if accessible_location(location)]
-        minimum_level = legendary_levels.get(fish_id, 0)
+        if fish_id not in FISH_LOCATIONS:
+            accessible_catalog_locations = [
+                catalog_location(entry)
+                for entry in catalog_locations
+                if entry.get("verified") and (
+                    str(entry.get("id") or "") in saved_locations
+                    or str(entry.get("id") or "") in {"Beach", "Town", "Forest", "Mountain", "Woods", "Sewer", "Desert"}
+                )
+            ]
+            accessible = list(dict.fromkeys(location for location in accessible_catalog_locations if location))
+        minimum_level = max(
+            [legendary_levels.get(fish_id, 0)]
+            + [int(entry.get("minFishingLevel") or 0) for entry in catalog_locations]
+        )
         if progress.get("fishing", 0) < minimum_level:
             accessible = []
         fish_seasons = FISH_SEASONS.get(fish_id, parts[6].split())
         fish_weather = "rainy" if fish_id == "163" else parts[7]
         fish.append({
-            "id": fish_id, "name": parts[0], "difficulty": int(parts[1]), "behavior": parts[2],
+            "id": fish_id, "name": catalog_entry.get("name") or parts[0], "difficulty": int(parts[1]), "behavior": parts[2],
             "windows": windows, "seasons": fish_seasons, "weather": fish_weather,
-            "locations": locations, "accessibleLocations": accessible, "basePrice": FISH_PRICES.get(fish_id, 0),
-            "minFishingLevel": minimum_level, "caught": fish_id in caught,
+            "locations": locations, "accessibleLocations": accessible,
+            "basePrice": catalog_entry.get("basePrice") or FISH_PRICES.get(fish_id, 0),
+            "minFishingLevel": minimum_level, "caught": unqualified_item_id(fish_id) in caught,
+            "modded": bool(catalog_entry.get("modded", False)),
+            "verified": bool(catalog_entry.get("verified", fish_id in FISH_LOCATIONS)),
+            "spriteIndex": catalog_entry.get("spriteIndex"),
+            "artworkUrl": catalog_entry.get("artworkUrl"),
+            "artworkColumns": catalog_entry.get("artworkColumns"),
         })
     fish.sort(key=lambda item: (item["caught"], item["name"]))
     raining = (root.findtext("isRaining", "false") or "false").lower() == "true"

--- a/scripts/mod-compatibility.mjs
+++ b/scripts/mod-compatibility.mjs
@@ -10,7 +10,7 @@ const SAFE_CODE_MODS = new Set([
   "pathoschild.contentpatcher",
   "smapi.savebackup",
 ]);
-const SUPPORTED_CONTENT_PACK_DOMAINS = new Set(["items", "crops", "npcs"]);
+const SUPPORTED_CONTENT_PACK_DOMAINS = new Set(["items", "crops", "fish", "recipes", "npcs", "buildings", "locations"]);
 const DOMAIN_ORDER = ["items", "crops", "fish", "recipes", "machines", "animals", "npcs", "buildings", "locations", "maps", "quests", "other"];
 
 function domainForTarget(target) {

--- a/tests/mod-compatibility.test.mjs
+++ b/tests/mod-compatibility.test.mjs
@@ -81,6 +81,34 @@ test("supported local crop, object, and shop additions are catalog-aware", async
   }
 });
 
+test("safe fish, recipe, building, and location additions are catalog-aware", async () => {
+  const files = fixture();
+  try {
+    files.addMod("World Pack", {
+      UniqueID: "Example.World",
+      ContentPackFor: { UniqueID: "Pathoschild.ContentPatcher" },
+    }, { Changes: [
+      { Action: "EditData", Target: "Data/Fish", Entries: { "Example.Fish": "Example Fish/40/mixed/12/20/600 1200/spring/sunny/0/.4/0" } },
+      { Action: "EditData", Target: "Data/CookingRecipes", Entries: { "Example Meal": "24 1/10 1/Example.Meal" } },
+      { Action: "EditData", Target: "Data/Buildings", Entries: { "Example Shed": { Name: "Example Shed", BuildCost: 100 } } },
+      { Action: "EditData", Target: "Data/Locations", Entries: { "Example Lake": { DisplayName: "Example Lake", Fish: [] } } },
+      { Action: "EditData", Target: "Data/Locations", TargetField: ["Example Lake", "Fish"], Entries: { "Example.Spawn": { ItemId: "Example.Fish" } } },
+    ] });
+    const summary = scanModCompatibility(files.root);
+    assert.equal(summary.status, "mod-aware");
+    assert.deepEqual(summary.supportedDomains, ["fish", "recipes", "buildings", "locations"]);
+    assert.deepEqual(summary.uncertainDomains, []);
+    const overlay = await buildContentPatcherCatalogOverlay(files.root);
+    assert.equal(overlay.fish["Example.Fish"].startsWith("Example Fish/"), true);
+    assert.equal(overlay.cookingRecipes["Example Meal"], "24 1/10 1/Example.Meal");
+    assert.equal(overlay.buildings["Example Shed"].BuildCost, 100);
+    assert.equal(overlay.locations["Example Lake"].DisplayName, "Example Lake");
+    assert.equal(overlay.locationFish[0].items[0].ItemId, "Example.Fish");
+  } finally {
+    files.cleanup();
+  }
+});
+
 test("conditional or tokenized crop edits and code mods produce explicit uncertainty", async () => {
   const files = fixture();
   try {

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1177,6 +1177,21 @@ test("mod compatibility is contextual and copied diagnostics exclude farm identi
   assert.doesNotMatch(desktop, /profileId: profileIdForSave\(config\?\.savePath\)/);
 });
 
+test("modded fishing uses the local structured catalog and preserves uncertain rules", async () => {
+  const [page, generator, extractor] = await Promise.all([
+    readFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/generate_snapshot.py", import.meta.url), "utf8"),
+    readFile(new URL("../tools/StardewDataExtractor/Program.cs", import.meta.url), "utf8"),
+  ]);
+  assert.match(extractor, /fishing = fishingCatalog/);
+  assert.match(extractor, /Dictionary<string, LocationData> locations/);
+  assert.match(generator, /catalog_fish = \{/);
+  assert.match(generator, /catalog_entry\.get\("artworkUrl"\)/);
+  assert.match(generator, /"verified": bool\(catalog_entry\.get/);
+  assert.match(page, /fish\.modded && !fish\.verified/);
+  assert.match(page, /<ModdedItemArtwork url=\{fish\.artworkUrl\}/);
+});
+
 test("Farm and Plan remember separate sections while bundle links open Community Center", async () => {
   const page = await readFile(
     new URL("../app/page.tsx", import.meta.url),

--- a/tools/StardewDataExtractor/Program.cs
+++ b/tools/StardewDataExtractor/Program.cs
@@ -11,6 +11,7 @@ using StardewValley.GameData.FruitTrees;
 using StardewValley.GameData.FarmAnimals;
 using StardewValley.GameData.FishPonds;
 using StardewValley.GameData.Machines;
+using StardewValley.GameData.Locations;
 using StardewValley.GameData.Objects;
 using StardewValley.GameData.Shops;
 using StardewValley.GameData.WildTrees;
@@ -47,27 +48,80 @@ static class GameCatalogReader
         Dictionary<string, MachineData> machines = content.Load<Dictionary<string, MachineData>>("Data/Machines");
         Dictionary<string, BigCraftableData> bigCraftables = content.Load<Dictionary<string, BigCraftableData>>("Data/BigCraftables");
         Dictionary<string, BuildingData> buildings = content.Load<Dictionary<string, BuildingData>>("Data/Buildings");
+        Dictionary<string, LocationData> locations = content.Load<Dictionary<string, LocationData>>("Data/Locations");
+        Dictionary<string, string> fish = content.Load<Dictionary<string, string>>("Data/Fish");
         Dictionary<string, string> craftingRecipes = content.Load<Dictionary<string, string>>("Data/CraftingRecipes");
+        Dictionary<string, string> cookingRecipes = content.Load<Dictionary<string, string>>("Data/CookingRecipes");
         int skippedObjectEdits = 0;
         int skippedCropEdits = 0;
         int skippedShopEdits = 0;
+        int skippedFishEdits = 0;
+        int skippedRecipeEdits = 0;
+        int skippedBuildingEdits = 0;
+        int skippedLocationEdits = 0;
+        var moddedFishIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         if (!string.IsNullOrWhiteSpace(overlayPath) && File.Exists(overlayPath))
         {
             var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, IncludeFields = true };
             jsonOptions.Converters.Add(new JsonStringEnumConverter());
             CatalogOverlay? overlay = JsonSerializer.Deserialize<CatalogOverlay>(File.ReadAllText(overlayPath), jsonOptions);
+            if (overlay?.Fish is not null) moddedFishIds.UnionWith(overlay.Fish.Keys);
+            T? DeserializeEntry<T>(JsonElement entry) where T : class
+            {
+                try { return entry.Deserialize<T>(jsonOptions); }
+                catch { return null; }
+            }
             foreach ((string id, JsonElement entry) in overlay?.Objects ?? new())
             {
                 if (objects.ContainsKey(id)) { skippedObjectEdits += 1; continue; }
-                ObjectData? value = entry.Deserialize<ObjectData>(jsonOptions);
-                if (value is not null) objects[id] = value;
+                ObjectData? value = DeserializeEntry<ObjectData>(entry);
+                if (value is not null) objects[id] = value; else skippedObjectEdits += 1;
             }
             foreach ((string id, JsonElement entry) in overlay?.Crops ?? new())
             {
                 if (crops.ContainsKey(id)) { skippedCropEdits += 1; continue; }
-                CropData? value = entry.Deserialize<CropData>(jsonOptions);
-                if (value is not null) crops[id] = value;
+                CropData? value = DeserializeEntry<CropData>(entry);
+                if (value is not null) crops[id] = value; else skippedCropEdits += 1;
+            }
+            foreach ((string id, string entry) in overlay?.Fish ?? new())
+            {
+                if (fish.ContainsKey(id)) { skippedFishEdits += 1; continue; }
+                fish[id] = entry;
+            }
+            foreach ((string id, string entry) in overlay?.CookingRecipes ?? new())
+            {
+                if (cookingRecipes.ContainsKey(id)) { skippedRecipeEdits += 1; continue; }
+                cookingRecipes[id] = entry;
+            }
+            foreach ((string id, string entry) in overlay?.CraftingRecipes ?? new())
+            {
+                if (craftingRecipes.ContainsKey(id)) { skippedRecipeEdits += 1; continue; }
+                craftingRecipes[id] = entry;
+            }
+            foreach ((string id, JsonElement entry) in overlay?.Buildings ?? new())
+            {
+                if (buildings.ContainsKey(id)) { skippedBuildingEdits += 1; continue; }
+                BuildingData? value = DeserializeEntry<BuildingData>(entry);
+                if (value is not null) buildings[id] = value; else skippedBuildingEdits += 1;
+            }
+            foreach ((string id, JsonElement entry) in overlay?.Locations ?? new())
+            {
+                if (locations.ContainsKey(id)) { skippedLocationEdits += 1; continue; }
+                LocationData? value = DeserializeEntry<LocationData>(entry);
+                if (value is not null) locations[id] = value; else skippedLocationEdits += 1;
+            }
+            foreach (LocationFishOverlay addition in overlay?.LocationFish ?? new())
+            {
+                if (!locations.TryGetValue(addition.LocationId, out LocationData? location)) { skippedLocationEdits += addition.Items.Count; continue; }
+                location.Fish ??= new List<SpawnFishData>();
+                foreach (JsonElement entry in addition.Items)
+                {
+                    SpawnFishData? value = DeserializeEntry<SpawnFishData>(entry);
+                    if (value is null) { skippedLocationEdits += 1; continue; }
+                    if (location.Fish.Any(item => item.Id == value.Id)) { skippedLocationEdits += 1; continue; }
+                    location.Fish.Add(value);
+                }
             }
             foreach (ShopItemOverlay addition in overlay?.ShopItems ?? new())
             {
@@ -117,6 +171,55 @@ static class GameCatalogReader
             ObjectData? data = ObjectFor(qualifiedId);
             return new { id = qualifiedId, name = data?.Name ?? qualifiedId, price = data?.Price ?? 0, category = data?.Category, spriteIndex = data?.SpriteIndex, texture = data?.Texture };
         }
+
+        static int[] FishTimes(string[] parts)
+        {
+            if (parts.Length <= 5) return Array.Empty<int>();
+            return parts[5].Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Select(value => int.TryParse(value, out int parsed) ? parsed : -1)
+                .Where(value => value >= 0)
+                .ToArray();
+        }
+
+        var fishingCatalog = fish.Select(pair =>
+        {
+            string[] parts = pair.Value.Split('/');
+            string fishId = QualifyObject(pair.Key);
+            ObjectData? item = ObjectFor(fishId);
+            int[] times = FishTimes(parts);
+            var windows = Enumerable.Range(0, times.Length / 2)
+                .Select(index => new[] { times[index * 2], times[index * 2 + 1] }).ToArray();
+            var spawnLocations = locations
+                .SelectMany(location => (location.Value.Fish ?? new List<SpawnFishData>())
+                    .Where(spawn => QualifyObject(spawn.ItemId) == fishId)
+                    .Select(spawn => new
+                    {
+                        id = location.Key,
+                        displayName = location.Value.DisplayName,
+                        fishAreaId = spawn.FishAreaId,
+                        minFishingLevel = spawn.MinFishingLevel,
+                        condition = spawn.Condition,
+                        verified = string.IsNullOrWhiteSpace(spawn.Condition) && spawn.RandomItemId?.Count is not > 0,
+                    }))
+                .ToArray();
+            int.TryParse(parts.ElementAtOrDefault(1), out int difficulty);
+            return new
+            {
+                id = fishId,
+                name = item?.Name ?? parts.ElementAtOrDefault(0) ?? fishId,
+                difficulty,
+                behavior = parts.ElementAtOrDefault(2) ?? "mixed",
+                windows,
+                seasons = (parts.ElementAtOrDefault(6) ?? "").Split(' ', StringSplitOptions.RemoveEmptyEntries),
+                weather = parts.ElementAtOrDefault(7) ?? "both",
+                basePrice = item?.Price ?? 0,
+                spriteIndex = item?.SpriteIndex,
+                texture = item?.Texture,
+                locations = spawnLocations,
+                modded = moddedFishIds.Contains(pair.Key),
+                verified = item is not null && parts.Length >= 8 && windows.Length > 0 && spawnLocations.Any(location => location.verified),
+            };
+        }).Where(entry => entry.basePrice > 0).ToArray();
         object[] RecipeMaterials(string name)
         {
             string ingredients = craftingRecipes.GetValueOrDefault(name)?.Split('/').FirstOrDefault() ?? "";
@@ -484,7 +587,7 @@ static class GameCatalogReader
             .ToArray();
 
         return JsonSerializer.Serialize(
-            new { catalogVersion = 6, source = "local-game", crops = cropCatalog, fruitTrees = treeCatalog, fertilizers = fertilizerCatalog, tappedTrees = tappedTreeCatalog, mushroomLogs = mushroomLogRules, mushroomLogOutputs, forestryEquipment, artisanMachines, farmAnimals = animalCatalog, fishPonds = pondCatalog, feedUnitCost = PurchasePrice("(O)178"), overlayDiagnostics = new { skipped = new { items = skippedObjectEdits + skippedShopEdits, crops = skippedCropEdits } } },
+            new { catalogVersion = 7, source = "local-game", crops = cropCatalog, fruitTrees = treeCatalog, fertilizers = fertilizerCatalog, tappedTrees = tappedTreeCatalog, mushroomLogs = mushroomLogRules, mushroomLogOutputs, forestryEquipment, artisanMachines, farmAnimals = animalCatalog, fishPonds = pondCatalog, fishing = fishingCatalog, feedUnitCost = PurchasePrice("(O)178"), overlayDiagnostics = new { skipped = new { items = skippedObjectEdits + skippedShopEdits, crops = skippedCropEdits, fish = skippedFishEdits, recipes = skippedRecipeEdits, buildings = skippedBuildingEdits, locations = skippedLocationEdits } } },
             new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }
         );
     }
@@ -498,7 +601,19 @@ static class GameCatalogReader
     {
         public Dictionary<string, JsonElement> Objects { get; set; } = new();
         public Dictionary<string, JsonElement> Crops { get; set; } = new();
+        public Dictionary<string, string> Fish { get; set; } = new();
+        public Dictionary<string, string> CookingRecipes { get; set; } = new();
+        public Dictionary<string, string> CraftingRecipes { get; set; } = new();
+        public Dictionary<string, JsonElement> Buildings { get; set; } = new();
+        public Dictionary<string, JsonElement> Locations { get; set; } = new();
+        public List<LocationFishOverlay> LocationFish { get; set; } = new();
         public List<ShopItemOverlay> ShopItems { get; set; } = new();
+    }
+
+    private sealed class LocationFishOverlay
+    {
+        public string LocationId { get; set; } = "";
+        public List<JsonElement> Items { get; set; } = new();
     }
 
     private sealed class ShopItemOverlay


### PR DESCRIPTION
## Summary
- read safe Content Patcher additions for fish, recipes, buildings, and locations from the user's local installation
- build fishing availability from local Data/Fish and Data/Locations while retaining exact vanilla rules
- display locally extracted mod fish artwork and mark unverified conditional rules without inventing availability
- keep unsupported edits explicit in privacy-safe compatibility diagnostics

## Validation
- npm run desktop:game-data
- npm run lint
- npm test (130 tests)
- npm run verify:public
- generated a real snapshot from a private working copy and confirmed vanilla textual IDs remain vanilla

Part of #14.