### PR TITLE
fix(mods): verify compatibility across fishing and production consumers

### DIFF
--- a/MOD_COMPATIBILITY.md
+++ b/MOD_COMPATIBILITY.md
@@ -1,0 +1,24 @@
+# Local mod compatibility matrix
+
+This is a conservative static-data catalog, not a Content Patcher interpreter or a SMAPI runtime emulator. Additions are consumed only after validation. Existing entry replacements are skipped and diagnosed; a supported manifest alone never proves that every rule is modeled. All game data is read from the local installation. No game assets or save data belong in this repository.
+
+| Domain | Consumed additions | Unsupported edits and conditions | Runtime-only limitations |
+| --- | --- | --- | --- |
+| Objects and crops | New typed records, qualified output identities and extracted growth data | Existing entry replacement, partial directives, unresolved tokens, missing prices | Code-defined items and crop behavior |
+| Fish | New fish plus explicit location spawns; per-spawn season and fishing level | Conditional, spatial, distance, catch-limit and bait-specific spawns remain uncertain | Code-driven spawns and live map access |
+| Recipes | New cooking/crafting collection records with qualified output IDs and save-backed learned/completed state | Ingredient/unlock evaluation is not implemented for arbitrary additions; added recipe domains remain uncertain, as do replacement records | Arbitrary recipe unlock callbacks |
+| Buildings | New local records, material costs, build days and upgrade prerequisites | Unknown materials or build conditions prevent verification | Custom builders, interiors and code-driven upgrade rules |
+| NPCs | New typed character records consumed by the catalog | Replacement records and unresolved names are diagnosed | Custom schedules and interaction callbacks |
+| Machines / big craftables | New machine identities, deterministic item-placed fixed input/output rules, quantities and cycle times through the existing machine engine | Alternative triggers/outputs, callbacks, unknown inputs, unsupported modifiers and existing-record edits cannot be verified | Code-driven output methods, interactions and machine behavior |
+| Animals | New animal records with local building and produce references through the existing animal engine | Conditional/multiple produce selection, missing products/buildings and unlock rules remain uncertain | Code-driven animal behavior and shop access |
+| Fish ponds | New keyed pond rules with tags, precedence, population gates and local products through the existing pond engine | Conditional/random/unknown products remain uncertain; existing rules are not replaced | Custom pond callbacks and code-defined population logic |
+| Fruit / wild trees | New tree records, local fruit/tap products, growth and cycle data through existing production engines | Missing purchase prices, conditional/random/seasonal fruit or complex tap rules cannot be verified | Code-driven growth, fruit selection and map behavior |
+| Locations / maps | New location fish metadata and explicit fish-list additions | Unknown access never creates a confirmed route; map patch operations are diagnosed | Tile edits, warps, arbitrary map loading and access callbacks are not simulated |
+
+Forecasts flagged as uncertain are estimates. Local runtime observations do not automatically verify every future outcome. The parent compatibility issue must stay open until its original acceptance criteria are checked against this matrix and all child deliveries.
+
+## Reproducible validation
+
+`tests/mod-production-extractor.test.mjs` is an opt-in integration test: build the local extractor and set `STARDEW_PATH` to a legitimate installation, then run `node --test tests/mod-production-extractor.test.mjs`. The test writes only synthetic overlay input to a temporary directory and keeps extracted data in memory. Without the environment variable it is skipped so public CI does not require or distribute game content.
+
+Local validation on 2026-09-05: extractor built with no warnings/errors; synthetic additions for machines, animals, ponds and trees reached the existing consumers; the unchanged crop baseline compared equal; missing tree purchase cost and explicitly uncertain production were retained as warnings. This was a synthetic integration smoke test, not a claim that a particular installed mod pack or private save was verified. Manual in-app testing remains necessary before a release.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -342,6 +342,7 @@ type FishingFish = {
   caught: boolean;
   modded?: boolean;
   verified?: boolean;
+  uncertainLocations?: string[];
   spriteIndex?: number;
   artworkUrl?: string;
   artworkColumns?: number;
@@ -383,6 +384,9 @@ type CommunityRoom = {
   bundles: BundlePlan[];
 };
 type BuildingPlan = {
+  id?: string;
+  modded?: boolean;
+  verified?: boolean;
   name: string;
   category: "Robin" | "Upgrades" | "Wizard" | "Community";
   projectType: string;
@@ -396,7 +400,7 @@ type BuildingPlan = {
   footprint?: string;
   prerequisite?: string;
   unlock?: string;
-  materials: { name: string; displayName?: string; owned: number; needed: number }[];
+  materials: { id?: string; name: string; displayName?: string; owned: number; needed: number }[];
 };
 type CropPlan = {
   id?: string;
@@ -6239,7 +6243,7 @@ function FishingView({
                           : t("fishing.weather.sunny")}
                     </span>
                     <span>{t("fishing.difficulty", { difficulty: fish.difficulty })}</span>
-                    {fish.modded && !fish.verified && (
+                    {fish.verified === false && (
                       <span className="mod-rule-badge" title={t("fishing.modRuleDetail")}>
                         {t("fishing.modRuleUnverified")}
                       </span>
@@ -6321,7 +6325,7 @@ function FishingView({
                         {fishListMode === "all" && fish.caught && (
                           <em className="caught-badge">{t("fishing.caught")}</em>
                         )}
-                        {fish.modded && !fish.verified && (
+                        {fish.verified === false && (
                           <em className="mod-rule-badge" title={t("fishing.modRuleDetail")}>
                             {t("fishing.modRuleUnverified")}
                           </em>
@@ -7253,14 +7257,16 @@ function PlanningView({
   const buildingOptions = visibleBuildings.map((building) => {
     const materials = building.materials.map((material) => ({
       ...material,
-      owned: live.active ? inventoryCount(material.name) : material.owned,
+      owned: live.active ? material.id ? inventory.filter((item) => inventoryItemId(item) === material.id).reduce((sum, item) => sum + item.count, 0) : inventoryCount(material.name) : material.owned,
     }));
     const resourcesReady =
       buildingMoney >= building.money &&
       materials.every((item) => item.owned >= item.needed);
     const ready =
-      !building.completed && building.prerequisiteMet && resourcesReady;
-    const status = building.completed
+      !building.completed && building.verified !== false && building.prerequisiteMet && resourcesReady;
+    const status = building.verified === false
+      ? t("building.status.unverified")
+      : building.completed
       ? t("building.status.completed")
       : ready
         ? building.owned > 0
@@ -7314,11 +7320,11 @@ function PlanningView({
       recentEntries.length
     : 0;
   const constructionTargets: StrategicGoalTarget[] = availableBuildings
-    .filter((building) => !building.completed)
+    .filter((building) => !building.completed && building.verified !== false)
     .map((building) => {
       const materials = building.materials.map((material) => ({
         ...material,
-        owned: inventoryCount(material.name),
+        owned: material.id ? inventory.filter((item) => inventoryItemId(item) === material.id).reduce((sum, item) => sum + item.count, 0) : inventoryCount(material.name),
       }));
       const missing = materials.filter(
         (material) => material.owned < material.needed,
@@ -7772,7 +7778,7 @@ function PlanningView({
             currentMachines={current.planningBrief.machines}
             currentHouseUpgradeLevel={current.progress.houseUpgradeLevel}
             currentAnimals={current.planningBrief.animals}
-            currentBuildings={current.planningBrief.buildings}
+            currentBuildings={current.planningBrief.buildings.map((building) => ({ ...building, cost: building.money }))}
             currentPonds={current.planningBrief.fishPonds}
             profileId={current.profileId || `${current.farmName}-${current.farmer}`}
             resolveGameName={gameName}
@@ -8005,7 +8011,7 @@ function PlanningView({
                                   <span>{t("web.planning.footprint")}{building.footprint}</span>
                                 )}
                                 {building.prerequisite && (
-                                  <span className="met">✓ {buildingPlanText(building, "prerequisite", t)}</span>
+                                  <span className={building.prerequisiteMet ? "met" : ""}>{building.prerequisiteMet ? "✓ " : ""} {buildingPlanText(building, "prerequisite", t)}</span>
                                 )}
                               </div>
                             </div>

--- a/app/planning/animal-engine.mjs
+++ b/app/planning/animal-engine.mjs
@@ -67,6 +67,7 @@ export function calculateAnimalPlan(input) {
   addOutput(deluxe, expectedDeluxeCycles);
   addOutput(processor?.output, processedCycles * Math.max(0, Number(processor?.outputCount) || 1));
   const warnings = [...horizon.warnings];
+  if (animal.verified === false) warnings.push("unverified-producer-data");
   if (!fedDaily) warnings.push("animal-not-fed");
   if (!animal.purchasable && newCount > 0) warnings.push("animal-not-purchasable");
   if (Number.isFinite(input.buildingCapacity) && count > input.buildingCapacity) warnings.push("animal-building-capacity");

--- a/app/planning/pond-engine.mjs
+++ b/app/planning/pond-engine.mjs
@@ -114,6 +114,7 @@ export function calculateFishPondPlan(input) {
     return [key, { units: Math.round(units[key] * pondCount * 100) / 100, grossRevenue, netProfit, profitPerDay: horizon.durationDays ? Math.floor(netProfit / horizon.durationDays) : netProfit }];
   }));
   const warnings = [...horizon.warnings];
+  if (pond.verified === false) warnings.push("unverified-producer-data");
   if (unlockedPopulation < pond.maxPopulation) warnings.push("pond-population-gated");
   if (pond.producedItems?.some(item => item.condition)) warnings.push("pond-conditional-output");
   if (processRoe) warnings.push("pond-roe-processing-estimate");

--- a/app/planning/production-calculator.tsx
+++ b/app/planning/production-calculator.tsx
@@ -32,12 +32,14 @@ export type ProductionCatalogEntry = Omit<ProductionProducer, "outputValue"> & {
   pond?: ProductionPond;
 };
 export type ProductionAnimal = {
+  verified?: boolean;
   id: string; name: string; texture?: string; artworkUrl?: string; spriteWidth?: number; spriteHeight?: number; purchasePrice: number; purchasable: boolean; requiredBuilding: string; buildingCapacity: number; buildingCost: number; daysToMature: number; daysToProduce: number;
   harvestType: string; produceOnMature: boolean; deluxeProduceMinimumFriendship: number; deluxeProduceCareDivisor: number;
   produce: Array<{ item: { id: string; name: string; price: number; spriteIndex?: number } }>;
   deluxeProduce: Array<{ item: { id: string; name: string; price: number; spriteIndex?: number } }>;
 };
 export type ProductionPond = {
+  verified?: boolean;
   id: string; fish: { id: string; name: string; price: number; spriteIndex?: number }; ruleId: string; maxPopulation: number; spawnTime: number;
   processedRoe?: { id: string; name: string; price: number; spriteIndex?: number };
   baseMinProduceChance: number; baseMaxProduceChance: number; populationGates?: Record<string, string[]>;
@@ -59,7 +61,7 @@ export type ProductionCatalog = {
   crops: ProductionCatalogEntry[];
   fruitTrees: ProductionCatalogEntry[];
   fertilizers?: ProductionFertilizer[];
-  tappedTrees?: Array<{ id: string; treeType: string; seed: { id: string; name: string; price: number; spriteIndex?: number }; growthChance: number; fertilizedGrowthChance: number; growsInWinter: boolean; tapItems: Array<{ itemId: string; item: { id: string; name: string; price: number; spriteIndex?: number } | null; daysUntilReady: number; condition?: string | null; season?: string | null; hasTimeModifiers?: boolean }> }>;
+  tappedTrees?: Array<{ verified?: boolean; id: string; treeType: string; seed: { id: string; name: string; price: number; spriteIndex?: number }; growthChance: number; fertilizedGrowthChance: number; growsInWinter: boolean; tapItems: Array<{ itemId: string; item: { id: string; name: string; price: number; spriteIndex?: number } | null; daysUntilReady: number; condition?: string | null; season?: string | null; hasTimeModifiers?: boolean }> }>;
   mushroomLogOutputs?: Array<{ id: string; name: string; price: number; spriteIndex?: number }>;
   forestryEquipment?: Array<{ id: string; name: string; spriteIndex?: number; opportunityCost: number; materials: Array<{ item: { id: string; name: string; price: number; spriteIndex?: number }; quantity: number }> }>;
   artisanMachines?: MachineConversion[];
@@ -167,7 +169,7 @@ function buildCalculatorEntries(catalog: ProductionCatalog | undefined, forestry
       startupCost: forestry.existing ? 0 : tree.seed.price + (tapper?.opportunityCost || 0),
       yield: { min: 1, expected: 1, max: 1 },
       space: 1,
-      verified: Boolean(tappedItem.item?.price),
+      verified: tree.verified !== false && Boolean(tappedItem.item?.price),
       materials: forestry.existing ? [] : [...(tapper?.materials || []), { item: tree.seed, quantity: 1 }],
     };
   });
@@ -209,9 +211,9 @@ function buildCalculatorEntries(catalog: ProductionCatalog | undefined, forestry
   }));
   const animalEntries: ProductionCatalogEntry[] = (catalog?.farmAnimals || []).flatMap(animal => {
     const output = animal.produce?.[0]?.item;
-    return output ? [{ id: animal.id, kind: "animal", family: "animal", name: animal.name, output, seasons: [], firstOutputDays: animal.daysToMature + animal.daysToProduce, repeatDays: animal.daysToProduce, startupCost: animal.purchasePrice, yield: { min: 1, expected: 1, max: 1 }, space: 1, verified: output.price > 0, animal }] : [];
+    return output ? [{ id: animal.id, kind: "animal", family: "animal", name: animal.name, output, seasons: [], firstOutputDays: animal.daysToMature + animal.daysToProduce, repeatDays: animal.daysToProduce, startupCost: animal.purchasePrice, yield: { min: 1, expected: 1, max: 1 }, space: 1, verified: animal.verified !== false && output.price > 0, animal }] : [];
   });
-  const pondEntries: ProductionCatalogEntry[] = (catalog?.fishPonds || []).map(pond => ({ id: pond.id, kind: "fish-pond", family: "pond", name: pond.fish.name, output: pond.fish, seasons: [], firstOutputDays: 1, repeatDays: 1, startupCost: 0, yield: { min: 0, expected: 1, max: 1 }, space: 25, verified: pond.fish.price > 0, pond }));
+  const pondEntries: ProductionCatalogEntry[] = (catalog?.fishPonds || []).map(pond => ({ id: pond.id, kind: "fish-pond", family: "pond", name: pond.fish.name, output: pond.fish, seasons: [], firstOutputDays: 1, repeatDays: 1, startupCost: 0, yield: { min: 0, expected: 1, max: 1 }, space: 25, verified: pond.verified !== false && pond.fish.price > 0, pond }));
   return [...farming, ...tapped, ...mushroomLog, ...machineEntries, ...animalEntries, ...pondEntries];
 }
 
@@ -255,7 +257,7 @@ function normalizeRecurringResult(id: string, quantity: number, space: number, p
   return {
     producerId: id, mode: "units", requestedAmount: quantity, location: "farm", replant: false, forcePlantToday: false,
     plantingDate: null, plantingDelayDays: 0, startDate: plan.startDate, endDate: plan.endDate, durationDays: plan.durationDays,
-    quantity, requiredSpace: space, investment: plan.purchaseCost || 0, recurringCosts: plan.feedCost || 0,
+    quantity, requiredSpace: space, investment: plan.purchaseCost || 0, recurringCosts: "feedCost" in plan ? plan.feedCost || 0 : 0,
     totalCosts: plan.totalCosts || 0, setupCosts: 0, unusedBudget: 0, harvestDates: [], breakEvenDate: plan.breakEvenDate,
     scenarios, warnings: plan.warnings || [],
   };
@@ -498,7 +500,7 @@ export function ProductionCalculator({
     let cancelled = false;
     const restore = window.setTimeout(async () => {
       try {
-        const preferences = await fetch("/api/preferences", { cache: "no-store" }).then(response => response.ok ? response.json() : {});
+        const preferences = await fetch("/api/preferences", { cache: "no-store" }).then(response => response.ok ? response.json() : {}) as Record<string, unknown>;
         let stored = preferences?.productionPlanning as {
           current?: Partial<SavedCalculation>;
           bookmarks?: SavedCalculation[];

--- a/desktop/main.mjs
+++ b/desktop/main.mjs
@@ -433,7 +433,7 @@ function extractedAssetsAreStale(config, requiredAssets) {
   if (!existsSync(gameData)) return true;
   const extracted = readJson(gameData, {});
   if (
-    extracted?._localization?.catalogVersion !== 11
+    extracted?._localization?.catalogVersion !== 12
   )
     return true;
   return (

--- a/locales/en.json
+++ b/locales/en.json
@@ -183,7 +183,7 @@
   "fishing.here": "HERE",
   "fishing.caught": "CAUGHT",
   "fishing.modRuleUnverified": "MOD RULE",
-  "fishing.modRuleDetail": "This fish comes from a mod with availability conditions Companion cannot fully verify.",
+  "fishing.modRuleDetail": "The availability conditions for this fish cannot be fully verified.",
   "fishing.wiki": "Wiki",
   "fishing.noneMissingNow": "No available fish are missing at this time in this weather. Change the time to plan the rest of the day.",
   "fishing.noneAvailableNow": "No fish are available at this time in this weather.",
@@ -1868,5 +1868,6 @@
   "compatibility.domain.locations": "Locations",
   "compatibility.domain.maps": "Maps",
   "compatibility.domain.quests": "Quests and orders",
-  "compatibility.domain.other": "Other or dynamic data"
+  "compatibility.domain.other": "Other or dynamic data",
+  "building.status.unverified": "Unverified building rules"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -183,7 +183,7 @@
   "fishing.here": "AQUÍ",
   "fishing.caught": "CAPTURADO",
   "fishing.modRuleUnverified": "REGLA DE MOD",
-  "fishing.modRuleDetail": "Este pez procede de un mod con condiciones de disponibilidad que Companion no puede verificar por completo.",
+  "fishing.modRuleDetail": "Las condiciones de disponibilidad de este pez no se pueden verificar por completo.",
   "fishing.wiki": "Wiki",
   "fishing.noneMissingNow": "No te falta ningún pez disponible a esta hora y con este tiempo. Cambia la hora para planificar el resto del día.",
   "fishing.noneAvailableNow": "No hay peces disponibles a esta hora y con este tiempo.",
@@ -1868,5 +1868,6 @@
   "compatibility.domain.locations": "Ubicaciones",
   "compatibility.domain.maps": "Mapas",
   "compatibility.domain.quests": "Misiones y encargos",
-  "compatibility.domain.other": "Otros datos o datos dinámicos"
+  "compatibility.domain.other": "Otros datos o datos dinámicos",
+  "building.status.unverified": "Reglas de construcción sin verificar"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node scripts/dev-local.mjs",
     "build": "npm run verify:changelog && vinext build && node scripts/prepare-built-public.mjs",
     "start": "vinext start",
-    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs",
+    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs tests/fishing-snapshot.test.mjs tests/mod-consumers.test.mjs tests/mod-production-extractor.test.mjs",
     "verify:changelog": "node scripts/verify-changelog.mjs",
     "verify:localization": "node scripts/verify-localization-ui.mjs",
     "verify:public": "node scripts/verify-public-safety.mjs",

--- a/scripts/content-patcher-catalog.mjs
+++ b/scripts/content-patcher-catalog.mjs
@@ -1,146 +1,142 @@
-import { existsSync } from "node:fs";
-import { readFile, readdir } from "node:fs/promises";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-
 import JSON5 from "json5";
 
-const MAX_DEPTH = 8;
+const DICTIONARIES = {
+  "data/objects": "objects", "data/crops": "crops", "data/fish": "fish",
+  "data/cookingrecipes": "cookingRecipes", "data/craftingrecipes": "craftingRecipes",
+  "data/buildings": "buildings", "data/locations": "locations",
+  "data/characters": "characters", "data/npcgifttastes": "npcGiftTastes",
+  "data/bigcraftables": "bigCraftables", "data/machines": "machines",
+  "data/farmanimals": "farmAnimals", "data/fruittrees": "fruitTrees",
+  "data/wildtrees": "wildTrees", "data/fishponddata": "fishPondData",
+};
+const STRING_TARGETS = new Set(["data/fish", "data/cookingrecipes", "data/craftingrecipes", "data/npcgifttastes"]);
+const hasRuntimeTokens = (value) => /\{\{/.test(JSON.stringify(value));
+const plainObject = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const values = (value) => (Array.isArray(value) ? value : String(value || "").split(",")).map(String).map((entry) => entry.trim()).filter(Boolean);
+const normalize = (value) => String(value).replace(/\\/g, "/").toLowerCase();
+const inside = (root, path) => { const rel = relative(root, path); return rel !== ".." && !rel.startsWith("../") && !rel.startsWith("..\\") && !/^[A-Za-z]:/.test(rel); };
 
-async function readJson5(path) {
-  return JSON5.parse(await readFile(path, "utf8"));
+export function supportedDataEdit(change, target) {
+  if (!plainObject(change) || String(change.Action || "").toLowerCase() !== "editdata") return false;
+  // Only additions are interpreted. Other directives can change entry identity or order.
+  const allowed = new Set(["Action", "Target", "Entries", "TargetField", "LogName"]);
+  if (Object.keys(change).some((key) => !allowed.has(key)) || hasRuntimeTokens(change)) return false;
+  if (!plainObject(change.Entries)) return false;
+  if (change.TargetField !== undefined && !Array.isArray(change.TargetField)) return false;
+  const field = change.TargetField || [];
+  if (field.length) {
+    return ["data/shops", "data/locations"].includes(target) && field.length === 2 &&
+      typeof field[0] === "string" && field[0].length > 0 && typeof field[1] === "string" &&
+      field[1].toLowerCase() === (target === "data/shops" ? "items" : "fish") &&
+      Object.values(change.Entries).every(plainObject);
+  }
+  if (!DICTIONARIES[target]) return false;
+  return Object.values(change.Entries).every((entry) => STRING_TARGETS.has(target) ? typeof entry === "string" : plainObject(entry));
 }
 
-async function manifestPaths(root, depth = 0) {
+export function supportedAssetLoad(change, target) {
+  return plainObject(change) && String(change.Action || "").toLowerCase() === "load" &&
+    Object.keys(change).every((key) => ["Action", "Target", "FromFile", "LogName"].includes(key)) &&
+    (/^mods\//i.test(target) || /^(characters|portraits)\/[^/]+$/i.test(target)) &&
+    typeof change.FromFile === "string" && !hasRuntimeTokens(change) && /\.png$/i.test(change.FromFile);
+}
+
+export function createCatalogState() {
+  return {
+    overlay: { ...Object.fromEntries(Object.values(DICTIONARIES).map((key) => [key, {}])), locationFish: [], shopItems: [], textures: {}, npcTextures: {} },
+    changes: [], claims: new Map(), unsupportedChangeCount: 0, parseFailureCount: 0,
+  };
+}
+
+function claim(state, identity, destination, key, value, record) {
+  const previous = state.claims.get(identity);
+  if (previous) {
+    previous.record.supported = false;
+    record.supported = false;
+    delete previous.destination[previous.key];
+    return;
+  }
+  // Define an own property even for a mod identifier named __proto__.
+  Object.defineProperty(destination, key, { value, writable: true, configurable: true, enumerable: true });
+  state.claims.set(identity, { destination, key, record });
+}
+
+export function inspectContentPatcherPack(packRoot, state, path = join(packRoot, "content.json"), visited = new Set(), depth = 0, uncertain = false) {
+  const resolved = resolve(path);
+  if (depth > 8 || !inside(packRoot, resolved) || visited.has(resolved)) { state.unsupportedChangeCount++; return; }
+  visited.add(resolved);
+  let content;
+  try {
+    if (statSync(resolved).size > 4 * 1024 * 1024) throw new Error("Too large");
+    content = JSON5.parse(readFileSync(resolved, "utf8"));
+    if (!plainObject(content) || !Array.isArray(content.Changes)) throw new Error("Invalid Changes");
+  } catch { state.parseFailureCount++; return; }
+  for (const change of content.Changes) {
+    if (!plainObject(change)) { state.unsupportedChangeCount++; continue; }
+    if (String(change.Action || "").toLowerCase() === "include") {
+      const includes = values(change.FromFile);
+      const skipped = uncertain || Object.keys(change).some((key) => !["Action", "FromFile", "LogName"].includes(key));
+      if (skipped) state.unsupportedChangeCount++;
+      if (!includes.length || hasRuntimeTokens(change.FromFile)) { state.unsupportedChangeCount++; continue; }
+      // Traverse static conditional includes only to identify affected domains, never to consume data.
+      for (const include of includes) inspectContentPatcherPack(packRoot, state, resolve(dirname(resolved), include), new Set(visited), depth + 1, skipped);
+      continue;
+    }
+    const targets = values(change.Target);
+    if (!targets.length) { state.unsupportedChangeCount++; continue; }
+    for (const originalTarget of targets) {
+      const target = normalize(originalTarget);
+      const asset = supportedAssetLoad(change, target);
+      const record = { target, supported: !uncertain && (asset || supportedDataEdit(change, target)), asset };
+      state.changes.push(record);
+      if (!record.supported) continue;
+      if (asset) {
+        const source = resolve(packRoot, change.FromFile);
+        if (!inside(packRoot, source) || !existsSync(source)) { record.supported = false; continue; }
+        const destination = /^mods\//.test(target) ? state.overlay.textures : state.overlay.npcTextures;
+        claim(state, target, destination, destination === state.overlay.npcTextures ? originalTarget.replace(/\\/g, "/") : target, source, record);
+      } else if (change.TargetField?.length) {
+        const [parentId] = change.TargetField;
+        const destination = {};
+        const list = target === "data/shops" ? state.overlay.shopItems : state.overlay.locationFish;
+        const entry = { [target === "data/shops" ? "shopId" : "locationId"]: parentId };
+        Object.defineProperty(entry, "items", { enumerable: true, get: () => Object.values(destination) });
+        list.push(entry);
+        for (const [id, value] of Object.entries(change.Entries))
+          claim(state, JSON.stringify([target, parentId, value.Id || id]), destination, id, { ...value, Id: value.Id || id }, record);
+      } else {
+        for (const [id, value] of Object.entries(change.Entries))
+          claim(state, JSON.stringify([target, id]), state.overlay[DICTIONARIES[target]], id, value, record);
+      }
+    }
+  }
+}
+
+function manifestPaths(root, depth = 0) {
   if (!root || depth > 4) return [];
   const found = [];
   try {
-    for (const entry of await readdir(root, { withFileTypes: true })) {
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
       if (!entry.isDirectory() || entry.isSymbolicLink() || entry.name.startsWith(".")) continue;
       const directory = join(root, entry.name);
       const manifest = join(directory, "manifest.json");
       if (existsSync(manifest)) found.push(manifest);
-      else found.push(...await manifestPaths(directory, depth + 1));
+      else found.push(...manifestPaths(directory, depth + 1));
     }
-  } catch {
-    // A missing or unreadable Mods directory is equivalent to no overlays.
-  }
+  } catch { /* Diagnostics report unreadable input separately. */ }
   return found;
 }
 
-function plainEntries(value) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return Object.values(value).every((entry) => entry && typeof entry === "object" && !Array.isArray(entry)) ? value : null;
-}
-
-function stringEntries(value) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  return Object.values(value).every((entry) => typeof entry === "string") ? value : null;
-}
-
-function hasRuntimeTokens(value) {
-  return /\{\{/.test(JSON.stringify(value));
-}
-
-function targets(value) {
-  return (Array.isArray(value) ? value : String(value || "").split(","))
-    .map((entry) => String(entry).trim().replace(/\\/g, "/").toLowerCase())
-    .filter(Boolean);
-}
-
-function filePaths(value) {
-  return (Array.isArray(value) ? value : String(value || "").split(","))
-    .map((entry) => String(entry).trim())
-    .filter(Boolean);
-}
-
-function supportedDataEdit(change, target) {
-  if (String(change?.Action || "").toLowerCase() !== "editdata" || change.When || change.Fields || change.MoveEntries)
-    return false;
-  const entries = plainEntries(change.Entries) || stringEntries(change.Entries);
-  if (!entries || hasRuntimeTokens(entries)) return false;
-  const targetField = Array.isArray(change.TargetField) ? change.TargetField.map(String) : [];
-  if (["data/objects", "data/crops", "data/buildings"].includes(target))
-    return targetField.length === 0 && plainEntries(entries) !== null;
-  if (target === "data/locations" && targetField.length === 0)
-    return plainEntries(entries) !== null;
-  if (["data/fish", "data/cookingrecipes", "data/craftingrecipes"].includes(target))
-    return targetField.length === 0 && stringEntries(entries) !== null;
-  if (target === "data/locations")
-    return targetField.length === 2 && targetField[1].toLowerCase() === "fish" && plainEntries(entries) !== null;
-  return target === "data/shops" && targetField.length === 2 && targetField[1].toLowerCase() === "items";
-}
-
-function supportedAssetLoad(change, target) {
-  return String(change?.Action || "").toLowerCase() === "load" &&
-    !change.When &&
-    /^mods\//i.test(target) &&
-    typeof change.FromFile === "string" &&
-    !hasRuntimeTokens(change.FromFile) &&
-    /\.png$/i.test(change.FromFile);
-}
-
-function addEdit(overlay, change, target) {
-  if (!supportedDataEdit(change, target)) return false;
-  if (target === "data/objects") Object.assign(overlay.objects, change.Entries);
-  else if (target === "data/crops") Object.assign(overlay.crops, change.Entries);
-  else if (target === "data/fish") Object.assign(overlay.fish, change.Entries);
-  else if (target === "data/cookingrecipes") Object.assign(overlay.cookingRecipes, change.Entries);
-  else if (target === "data/craftingrecipes") Object.assign(overlay.craftingRecipes, change.Entries);
-  else if (target === "data/buildings") Object.assign(overlay.buildings, change.Entries);
-  else if (target === "data/locations" && !change.TargetField?.length) Object.assign(overlay.locations, change.Entries);
-  else if (target === "data/locations") {
-    overlay.locationFish.push({
-      locationId: String(change.TargetField[0]),
-      items: Object.entries(change.Entries).map(([id, item]) => ({ ...item, Id: item.Id || id })),
-    });
-  }
-  else {
-    overlay.shopItems.push({
-      shopId: String(change.TargetField[0]),
-      items: Object.entries(change.Entries).map(([id, item]) => ({ ...item, Id: item.Id || id })),
-    });
-  }
-  return true;
-}
-
-async function inspectContentFile(path, packRoot, overlay, visited, depth = 0) {
-  const resolved = resolve(path);
-  if (depth > MAX_DEPTH || relative(packRoot, resolved).startsWith("..") || visited.has(resolved)) return;
-  visited.add(resolved);
-  const content = await readJson5(resolved);
-  for (const change of Array.isArray(content.Changes) ? content.Changes : []) {
-    const action = String(change?.Action || "").toLowerCase();
-    if (action === "include" && !change.When && !hasRuntimeTokens(change.FromFile)) {
-      for (const include of filePaths(change.FromFile))
-        await inspectContentFile(resolve(dirname(resolved), include), packRoot, overlay, visited, depth + 1);
-      continue;
-    }
-    for (const target of targets(change?.Target)) {
-      if (supportedAssetLoad(change, target)) {
-        const source = resolve(packRoot, change.FromFile);
-        if (!relative(packRoot, source).startsWith("..")) overlay.textures[target] = source;
-      } else addEdit(overlay, change, target);
-    }
-  }
-}
-
 export async function buildContentPatcherCatalogOverlay(modsRoot) {
-  const overlay = {
-    objects: {}, crops: {}, fish: {}, cookingRecipes: {}, craftingRecipes: {},
-    buildings: {}, locations: {}, locationFish: [], shopItems: [], textures: {},
-  };
-  for (const manifestPath of await manifestPaths(modsRoot)) {
+  const state = createCatalogState();
+  for (const manifestPath of manifestPaths(modsRoot)) {
     try {
-      const manifest = await readJson5(manifestPath);
-      if (String(manifest?.ContentPackFor?.UniqueID || "").toLowerCase() !== "pathoschild.contentpatcher") continue;
-      const packRoot = dirname(manifestPath);
-      const contentPath = join(packRoot, "content.json");
-      if (existsSync(contentPath)) await inspectContentFile(contentPath, packRoot, overlay, new Set());
-    } catch {
-      // Compatibility diagnostics report unreadable packs; extraction stays usable.
-    }
+      const manifest = JSON5.parse(readFileSync(manifestPath, "utf8"));
+      if (String(manifest?.ContentPackFor?.UniqueID || "").toLowerCase() === "pathoschild.contentpatcher")
+        inspectContentPatcherPack(dirname(manifestPath), state);
+    } catch { /* Compatibility scanner reports parse failures. */ }
   }
-  return overlay;
+  return state.overlay;
 }
-
-export { supportedAssetLoad, supportedDataEdit };

--- a/scripts/extract_game_data.mjs
+++ b/scripts/extract_game_data.mjs
@@ -1,16 +1,17 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { copyFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { extname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { unpackToFiles } from "xnb";
-import JSON5 from "json5";
 import { loadConfig, projectRoot, runtimeRoot, runtimePaths, validateConfig } from "./config.mjs";
 import { ensureRuntimeDirectories, syncRuntimePublic } from "./runtime-files.mjs";
 import { renderCommunityRooms } from "./render-community-rooms.mjs";
 import { localizedXnbPath } from "./localization.mjs";
 import { scanModCompatibility } from "./mod-compatibility.mjs";
 import { buildContentPatcherCatalogOverlay } from "./content-patcher-catalog.mjs";
+
+import { addCatalogEntries, npcMetadata } from "./mod-consumers.mjs";
 
 const config = loadConfig();
 const errors = validateConfig(config, { requireSave: false });
@@ -97,13 +98,9 @@ const fish = await unpack("Data/Fish.xnb");
 const cookingRecipes = await unpack("Data/CookingRecipes.xnb");
 const craftingRecipes = await unpack("Data/CraftingRecipes.xnb");
 const festivalDates = await unpack("Data/Festivals/FestivalDates.xnb");
-function addMissingEntries(target, additions) {
-  for (const [id, entry] of Object.entries(additions || {}))
-    if (!(id in target)) target[id] = entry;
-}
-addMissingEntries(fish, contentPatcherOverlay.fish);
-addMissingEntries(cookingRecipes, contentPatcherOverlay.cookingRecipes);
-addMissingEntries(craftingRecipes, contentPatcherOverlay.craftingRecipes);
+addCatalogEntries(fish, contentPatcherOverlay.fish, modCompatibility, "fish");
+addCatalogEntries(cookingRecipes, contentPatcherOverlay.cookingRecipes, modCompatibility, "recipes");
+addCatalogEntries(craftingRecipes, contentPatcherOverlay.craftingRecipes, modCompatibility, "recipes");
 async function extractProductionCatalog() {
   const executable = resolve(projectRoot, "desktop", "resources", "game-data-extractor", "StardewDataExtractor.exe");
   if (!existsSync(executable))
@@ -150,6 +147,7 @@ await attachContentPatcherArtwork(productionCatalog, contentPatcherOverlay);
 for (const [domain, skipped] of Object.entries(productionCatalog.overlayDiagnostics?.skipped || {})) {
   if (!skipped) continue;
   modCompatibility.status = "uncertain";
+  modCompatibility.supportedDomains = modCompatibility.supportedDomains.filter((value) => value !== domain);
   modCompatibility.uncertainDomains = [...new Set([...modCompatibility.uncertainDomains, domain])];
 }
 async function buildGameLocalizationCatalog(catalogLanguage, catalogLocale, catalogSuffix) {
@@ -190,7 +188,7 @@ async function buildGameLocalizationCatalog(catalogLanguage, catalogLocale, cata
   return {
     language: catalogLanguage,
     locale: catalogLocale,
-    catalogVersion: 11,
+    catalogVersion: 12,
     objectNames,
     localizedObjectNamesByEnglish,
     localizedNamesByQualifiedId,
@@ -214,7 +212,7 @@ const gameLocalizationCatalogs = Object.fromEntries(
 const activeLocalization = gameLocalizationCatalogs.en;
 
 const gameData = {
-  _localization: { language: "neutral", catalogVersion: 11 },
+  _localization: { language: "neutral", catalogVersion: 12 },
   modCompatibility,
   giftTastes: await unpack("Data/NPCGiftTastes.xnb"),
   cookingRecipes,
@@ -348,93 +346,33 @@ await Promise.all([
 ]);
 await renderCommunityRooms(project);
 
-async function findContentPacks(directory) {
-  const found = [];
-  try {
-    for (const entry of await readdir(directory, { withFileTypes: true })) {
-      const path = resolve(directory, entry.name);
-      if (entry.isDirectory()) found.push(...await findContentPacks(path));
-      else if (entry.name.toLowerCase() === "content.json") found.push(path);
-    }
-  } catch {
-    // A missing or unreadable Mods directory simply means there are no content packs to inspect.
+const characters = Object.fromEntries((productionCatalog.characterIds || []).map((id) => [id, null]));
+addCatalogEntries(characters, contentPatcherOverlay.characters, modCompatibility, "npcs");
+gameData.moddedCharacters = npcMetadata(Object.fromEntries(Object.entries(characters).filter(([, entry]) => entry !== null)));
+// Recipe collection progress can be read without claiming unlock/ingredient rules.
+if (Object.keys(contentPatcherOverlay.cookingRecipes || {}).length || Object.keys(contentPatcherOverlay.craftingRecipes || {}).length) {
+  modCompatibility.status = "uncertain";
+  modCompatibility.supportedDomains = modCompatibility.supportedDomains.filter((domain) => domain !== "recipes");
+  modCompatibility.uncertainDomains = [...new Set([...modCompatibility.uncertainDomains, "recipes"])];
+}
+if (Object.values(gameData.moddedCharacters).some((entry) => entry.displayName.startsWith("["))) {
+  modCompatibility.status = "uncertain";
+  modCompatibility.supportedDomains = modCompatibility.supportedDomains.filter((domain) => domain !== "npcs");
+  modCompatibility.uncertainDomains = [...new Set([...modCompatibility.uncertainDomains, "npcs"])];
+}
+
+addCatalogEntries(gameData.giftTastes, contentPatcherOverlay.npcGiftTastes, modCompatibility, "npcs");
+for (const [target, source] of Object.entries(contentPatcherOverlay.npcTextures || {})) {
+  const match = /^(characters|portraits)\/([a-z0-9_.-]+)$/i.exec(target);
+  if (!match) continue;
+  const destination = resolve(project, `public/assets/${match[1].toLowerCase()}/${match[2]}.png`);
+  await mkdir(resolve(destination, ".."), { recursive: true });
+  try { await copyFile(source, destination); }
+  catch {
+    modCompatibility.status = "uncertain";
+    modCompatibility.uncertainDomains = [...new Set([...modCompatibility.uncertainDomains, "npcs"])];
   }
-  return found;
 }
-
-async function readJson5(path, fallback = {}) {
-  try { return JSON5.parse(await readFile(path, "utf8")); }
-  catch { return fallback; }
-}
-
-function conditionMatches(when, configValues) {
-  return Object.entries(when || {}).every(([key, expected]) =>
-    key in configValues && String(configValues[key]).toLowerCase() === String(expected).toLowerCase(),
-  );
-}
-
-function resolveTokens(value, tokens) {
-  let resolved = String(value || "");
-  for (let pass = 0; pass < 5; pass += 1) {
-    const next = resolved.replace(/\{\{([^}:]+)(?::[^}]*)?\}\}/g, (match, name) => tokens[name] ?? match);
-    if (next === resolved) break;
-    resolved = next;
-  }
-  return resolved;
-}
-
-async function discoverModdedNpcs() {
-  const metadata = {};
-  const giftTastes = {};
-  let artworkCount = 0;
-  for (const contentPath of await findContentPacks(modsRoot)) {
-    const packRoot = resolve(contentPath, "..");
-    const content = await readJson5(contentPath);
-    const savedConfig = await readJson5(resolve(packRoot, "config.json"));
-    const configValues = Object.fromEntries(Object.entries(content.ConfigSchema || {}).map(([key, schema]) => [key, schema?.Default]));
-    Object.assign(configValues, savedConfig);
-    const tokens = {};
-    for (const token of content.DynamicTokens || []) {
-      if (token?.Name && conditionMatches(token.When, configValues)) tokens[token.Name] = resolveTokens(token.Value, tokens);
-    }
-    for (const change of content.Changes || []) {
-      if (!conditionMatches(change.When, configValues)) continue;
-      const target = resolveTokens(change.Target, tokens);
-      if (String(change.Action).toLowerCase() === "load" && change.FromFile) {
-        const match = /^(Characters|Portraits)\/([^/]+)$/i.exec(target);
-        const source = resolve(packRoot, resolveTokens(change.FromFile, tokens));
-        if (match && extname(source).toLowerCase() === ".png") {
-          const destination = resolve(project, `public/assets/${match[1].toLowerCase() === "characters" ? "characters" : "portraits"}/${match[2]}.png`);
-          try {
-            await mkdir(resolve(destination, ".."), { recursive: true });
-            await copyFile(source, destination);
-            artworkCount += 1;
-          } catch {
-            // Ignore optional or conditionally unavailable Content Patcher files.
-          }
-        }
-      }
-      if (String(change.Action).toLowerCase() === "editdata" && target.toLowerCase() === "data/characters" && change.Entries) {
-        for (const [id, entry] of Object.entries(change.Entries)) {
-          if (!entry || typeof entry !== "object") continue;
-          metadata[id] = {
-            displayName: entry.DisplayName || id,
-            birthSeason: entry.BirthSeason || null,
-            birthDay: Number(entry.BirthDay) || null,
-          };
-        }
-      }
-      if (String(change.Action).toLowerCase() === "editdata" && target.toLowerCase() === "data/npcgifttastes" && change.Entries) {
-        Object.assign(giftTastes, change.Entries);
-      }
-    }
-  }
-  return { metadata, giftTastes, artworkCount };
-}
-
-const moddedNpcs = await discoverModdedNpcs();
-gameData.moddedCharacters = moddedNpcs.metadata;
-Object.assign(gameData.giftTastes, moddedNpcs.giftTastes);
 await Promise.all([
   writeFile(resolve(project, "assetbuild/game-data.json"), JSON.stringify(gameData), "utf8"),
   ...Object.entries(gameLocalizationCatalogs).map(([catalogLanguage, catalog]) =>
@@ -445,5 +383,4 @@ await Promise.all([
     ),
   ),
 ]);
-if (moddedNpcs.artworkCount) console.log(`Imported ${moddedNpcs.artworkCount} modded NPC artwork files.`);
 syncRuntimePublic();

--- a/scripts/generate_snapshot.py
+++ b/scripts/generate_snapshot.py
@@ -1220,6 +1220,29 @@ def planning_brief(root: ET.Element, player: ET.Element, locations: ET.Element, 
             "affordable": money >= plan["money"] and all(item["owned"] >= item["needed"] for item in materials),
         })
 
+    inventory_by_id: dict[str, int] = {}
+    for item in available:
+        item_id = qualified_item_id(item.get("id", ""))
+        inventory_by_id[item_id] = inventory_by_id.get(item_id, 0) + item["count"]
+    for entry in game_data.get("productionCatalog", {}).get("buildings", []):
+        if not entry.get("modded"):
+            continue
+        materials = [{
+            "id": material["id"], "name": material.get("name") or material["id"],
+            "owned": inventory_by_id.get(material["id"], 0), "needed": material["count"],
+        } for material in entry.get("materials", [])]
+        prerequisite = entry.get("prerequisite") or ""
+        prerequisite_met = not prerequisite or placed_buildings.get(prerequisite, 0) > 0
+        verified = entry.get("verified") is True
+        buildings.append({
+            "id": entry["id"], "name": entry.get("name") or entry["id"],
+            "category": "Upgrades" if prerequisite else "Robin", "projectType": "Building upgrade" if prerequisite else "Farm building",
+            "money": entry["money"], "materials": materials, "why": "", "prerequisite": prerequisite,
+            "owned": placed_buildings.get(entry["id"], 0), "completed": False,
+            "prerequisiteMet": prerequisite_met, "available": True, "modded": True, "verified": verified,
+            "affordable": verified and prerequisite_met and money >= entry["money"] and all(item["owned"] >= item["needed"] for item in materials),
+        })
+
     crops = []
     days_left = 28 - day
     for plan in SEASON_CROP_PLANS.get(season, []):
@@ -1237,10 +1260,13 @@ def planning_brief(root: ET.Element, player: ET.Element, locations: ET.Element, 
     for item in player.findall("friendshipData/item"):
         name = item.findtext("key/string")
         value = item.find("value/Friendship")
-        if not name or name not in VANILLA_FRIENDSHIP_NPCS or value is None:
+        if not name or (name not in VANILLA_FRIENDSHIP_NPCS and name not in modded_characters) or value is None:
             continue
         points = number(value, "Points")
         birthday_date = next(((birthday_season, birthday) for (birthday_season, birthday), person in BIRTHDAYS.items() if person == name), None)
+        character = modded_characters.get(name, {})
+        if not birthday_date and character.get("birthSeason") and character.get("birthDay"):
+            birthday_date = (character["birthSeason"], character["birthDay"])
         birthday_day = None
         if birthday_date:
             birthday_season, birthday = birthday_date
@@ -1248,7 +1274,7 @@ def planning_brief(root: ET.Element, player: ET.Element, locations: ET.Element, 
             birthday_index = {"spring": 0, "summer": 1, "fall": 2, "winter": 3}.get(birthday_season, 0) * 28 + birthday
             birthday_day = (birthday_index - current_index) % 112
         friendships.append({
-            "id": name, "name": name, "points": points, "hearts": points // 250,
+            "id": name, "name": character.get("displayName") or name, "points": points, "hearts": points // 250,
             "talkedToday": bool_value(value, "TalkedToToday"), "giftsToday": number(value, "GiftsToday"),
             "giftsThisWeek": number(value, "GiftsThisWeek"),
             "daysToBirthday": birthday_day,
@@ -1552,9 +1578,10 @@ def fishing_brief(root: ET.Element, player: ET.Element, season: str, day: int, p
         game_data = json.loads(GAME_DATA.read_text(encoding="utf-8"))
         raw_fish = game_data.get("fish", {})
         catalog_fish = {
-            unqualified_item_id(item.get("id", "")): item
+            str(item.get("id", "")).removeprefix("(O)"): item
             for item in game_data.get("productionCatalog", {}).get("fishing", [])
             if isinstance(item, dict) and item.get("id")
+            and (not str(item["id"]).startswith("(") or str(item["id"]).startswith("(O)"))
         }
     except (OSError, json.JSONDecodeError):
         raw_fish = {}
@@ -1570,10 +1597,12 @@ def fishing_brief(root: ET.Element, player: ET.Element, season: str, day: int, p
     desert_open = any(key in mail for key in ("ccVault", "jojaVault", "ccVaultFin"))
     ginger_open = "willyBoatFixed" in mail
     legendary_levels = {"159": 5, "160": 3, "163": 10, "775": 6}
-    location_nodes = root.find("locations")
-    saved_locations = {
-        location.findtext("name", "")
-        for location in (location_nodes if location_nodes is not None else [])
+    # A serialized location can be a locked template. Only modeled progression
+    # gates prove access; presence in the save does not unlock a custom map.
+    supported_location_ids = {
+        "Beach", "Town", "Mountain", "Forest", "Woods", "Sewer", "Desert",
+        "WitchSwamp", "BugLand", "IslandSouth", "IslandSouthEast",
+        "IslandSouthEastCave", "IslandWest",
     }
 
     def catalog_location(entry: dict) -> str:
@@ -1614,35 +1643,56 @@ def fishing_brief(root: ET.Element, player: ET.Element, season: str, day: int, p
         parts = raw.split("/")
         if len(parts) < 9 or not parts[1].isdigit():
             continue
-        catalog_entry = catalog_fish.get(unqualified_item_id(fish_id), {})
+        fish_id = str(fish_id).removeprefix("(O)")
+        if fish_id.startswith("("):
+            continue
+        catalog_entry = catalog_fish.get(fish_id, {})
         times_raw = [int(value) for value in parts[5].split() if value.isdigit()]
         windows = catalog_entry.get("windows") or [
             [times_raw[index], times_raw[index + 1]]
             for index in range(0, len(times_raw) - 1, 2)
         ]
         catalog_locations = catalog_entry.get("locations") or []
-        locations = FISH_LOCATIONS.get(fish_id) or list(dict.fromkeys(
+        use_catalog_locations = fish_id not in FISH_LOCATIONS or catalog_entry.get("modded", False)
+        locations = (list(dict.fromkeys(
             catalog_location(entry) for entry in catalog_locations if catalog_location(entry)
-        ))
+        )) if use_catalog_locations else FISH_LOCATIONS[fish_id])
         if not locations:
             continue
-        accessible = [location for location in locations if accessible_location(location)]
-        if fish_id not in FISH_LOCATIONS:
-            accessible_catalog_locations = [
-                catalog_location(entry)
-                for entry in catalog_locations
-                if entry.get("verified") and (
-                    str(entry.get("id") or "") in saved_locations
-                    or str(entry.get("id") or "") in {"Beach", "Town", "Forest", "Mountain", "Woods", "Sewer", "Desert"}
+        minimum_level = legendary_levels.get(fish_id, 0)
+        uncertain_locations = []
+        if use_catalog_locations:
+            eligible = []
+            levels = []
+            for entry in catalog_locations:
+                location = catalog_location(entry)
+                try:
+                    level = max(minimum_level, int(entry.get("minFishingLevel") or 0))
+                except (ValueError, TypeError):
+                    uncertain_locations.append(location)
+                    continue
+                known_rules = (
+                    entry.get("verified") and not entry.get("condition")
+                    and not entry.get("unsupportedRules")
+                    and not entry.get("requireMagicBait")
+                    and not entry.get("ignoreFishDataRequirements")
+                    and str(entry.get("id") or "") in supported_location_ids
                 )
-            ]
-            accessible = list(dict.fromkeys(location for location in accessible_catalog_locations if location))
-        minimum_level = max(
-            [legendary_levels.get(fish_id, 0)]
-            + [int(entry.get("minFishingLevel") or 0) for entry in catalog_locations]
-        )
-        if progress.get("fishing", 0) < minimum_level:
-            accessible = []
+                if not known_rules:
+                    uncertain_locations.append(location)
+                    continue
+                levels.append(level)
+                spawn_season = str(entry.get("season") or "").lower()
+                if spawn_season and spawn_season != season:
+                    continue
+                if location and accessible_location(location) and progress.get("fishing", 0) >= level:
+                    eligible.append(location)
+            accessible = list(dict.fromkeys(eligible))
+            minimum_level = min(levels, default=minimum_level)
+        else:
+            accessible = [location for location in locations if accessible_location(location)]
+            if progress.get("fishing", 0) < minimum_level:
+                accessible = []
         fish_seasons = FISH_SEASONS.get(fish_id, parts[6].split())
         fish_weather = "rainy" if fish_id == "163" else parts[7]
         fish.append({
@@ -1652,7 +1702,8 @@ def fishing_brief(root: ET.Element, player: ET.Element, season: str, day: int, p
             "basePrice": catalog_entry.get("basePrice") or FISH_PRICES.get(fish_id, 0),
             "minFishingLevel": minimum_level, "caught": unqualified_item_id(fish_id) in caught,
             "modded": bool(catalog_entry.get("modded", False)),
-            "verified": bool(catalog_entry.get("verified", fish_id in FISH_LOCATIONS)),
+            "verified": (not uncertain_locations and (not use_catalog_locations or bool(catalog_entry.get("verified", False)))),
+            "uncertainLocations": list(dict.fromkeys(location for location in uncertain_locations if location)),
             "spriteIndex": catalog_entry.get("spriteIndex"),
             "artworkUrl": catalog_entry.get("artworkUrl"),
             "artworkColumns": catalog_entry.get("artworkColumns"),
@@ -2029,9 +2080,9 @@ def long_term_collection_brief(
     def output_details(recipe: str, crafting: bool = False) -> tuple[str, str]:
         parts = str(recipe).split("/")
         output = parts[2].split()[0] if len(parts) > 2 and parts[2].strip() else ""
-        output = output.removeprefix("(O)").removeprefix("(BC)")
         is_big = crafting and len(parts) > 3 and parts[3].strip().casefold() == "true"
-        return output, "craftable" if is_big else "object"
+        kind = "craftable" if is_big or output.startswith("(BC)") else "object"
+        return qualified_item_id(output, kind), kind
 
     cooking = []
     for name, recipe in game_data.get("cookingRecipes", {}).items():
@@ -2040,7 +2091,7 @@ def long_term_collection_brief(
         cooking.append({
             "id": item_id, "name": name, "complete": count > 0,
             "count": count, "learned": name in cooked,
-            "spriteKind": sprite_kind, "spriteIndex": item_id,
+            "spriteKind": sprite_kind, "spriteIndex": unqualified_item_id(item_id),
         })
 
     crafting = []
@@ -2052,7 +2103,7 @@ def long_term_collection_brief(
         crafting.append({
             "id": item_id, "name": name, "complete": count > 0,
             "count": count, "learned": name in crafted,
-            "spriteKind": sprite_kind, "spriteIndex": item_id,
+            "spriteKind": sprite_kind, "spriteIndex": unqualified_item_id(item_id),
         })
 
     return {

--- a/scripts/mod-compatibility.mjs
+++ b/scripts/mod-compatibility.mjs
@@ -1,8 +1,8 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join } from "node:path";
 
 import JSON5 from "json5";
-import { supportedAssetLoad, supportedDataEdit } from "./content-patcher-catalog.mjs";
+import { createCatalogState, inspectContentPatcherPack } from "./content-patcher-catalog.mjs";
 
 const SAFE_CODE_MODS = new Set([
   "maglucen.stardewvalleytoolbridge",
@@ -10,7 +10,7 @@ const SAFE_CODE_MODS = new Set([
   "pathoschild.contentpatcher",
   "smapi.savebackup",
 ]);
-const SUPPORTED_CONTENT_PACK_DOMAINS = new Set(["items", "crops", "fish", "recipes", "npcs", "buildings", "locations"]);
+const SUPPORTED_CONTENT_PACK_DOMAINS = new Set(["items", "crops", "fish", "recipes", "npcs", "buildings", "locations", "machines", "animals"]);
 const DOMAIN_ORDER = ["items", "crops", "fish", "recipes", "machines", "animals", "npcs", "buildings", "locations", "maps", "quests", "other"];
 
 function domainForTarget(target) {
@@ -29,17 +29,6 @@ function domainForTarget(target) {
   if (/^maps\//.test(normalized)) return "maps";
   if (/^data\/(quests|specialorders)/.test(normalized)) return "quests";
   return "other";
-}
-
-function supportedContentChange(change, target) {
-  const action = String(change?.Action || "").toLowerCase();
-  const normalized = String(target || "").replace(/\\/g, "/").toLowerCase();
-  if (supportedDataEdit(change, normalized)) return true;
-  return (
-    !change?.When &&
-    (action === "editdata" && ["data/characters", "data/npcgifttastes"].includes(normalized)) ||
-    (!change?.When && action === "load" && /^(characters|portraits)\/[^/]+$/.test(normalized))
-  );
 }
 
 function safeReadJson5(path, failures) {
@@ -69,53 +58,8 @@ function manifestPaths(root, depth = 0) {
   return found;
 }
 
-function targetsFromValue(value) {
-  if (Array.isArray(value)) return value.flatMap(targetsFromValue);
-  return String(value || "").split(",").map((target) => target.trim()).filter(Boolean);
-}
-
-function inspectContentFile(path, packRoot, state, visited, depth = 0) {
-  const resolvedPath = resolve(path);
-  const relativePath = relative(packRoot, resolvedPath);
-  if (depth > 8 || relativePath.startsWith("..") || visited.has(resolvedPath)) {
-    state.unsupportedChangeCount += 1;
-    return;
-  }
-  visited.add(resolvedPath);
-  const content = safeReadJson5(resolvedPath, state.failures);
-  if (!content) return;
-  const changes = Array.isArray(content.Changes) ? content.Changes : [];
-  for (const change of changes) {
-    if (!change || typeof change !== "object") continue;
-    const action = String(change.Action || "").toLowerCase();
-    if (action === "include") {
-      const includes = targetsFromValue(change.FromFile);
-      if (!includes.length || includes.some((entry) => entry.includes("{{"))) {
-        state.unsupportedChangeCount += 1;
-        continue;
-      }
-      for (const included of includes)
-        inspectContentFile(join(dirname(resolvedPath), included), packRoot, state, visited, depth + 1);
-      continue;
-    }
-    const targets = targetsFromValue(change.Target);
-    if (!targets.length) {
-      state.unsupportedChangeCount += 1;
-      continue;
-    }
-    for (const target of targets) {
-      if (supportedAssetLoad(change, target)) continue;
-      const domain = domainForTarget(target);
-      state.alteredDomains.add(domain);
-      if (domain === "other" || !SUPPORTED_CONTENT_PACK_DOMAINS.has(domain) || !supportedContentChange(change, target))
-        state.uncertainDomains.add(domain);
-      else
-        state.supportedDomains.add(domain);
-    }
-  }
-}
-
 export function scanModCompatibility(modsRoot) {
+  const catalog = createCatalogState();
   const state = {
     installedModCount: 0,
     contentPackCount: 0,
@@ -138,7 +82,7 @@ export function scanModCompatibility(modsRoot) {
       if (contentPackFor === "pathoschild.contentpatcher") {
         const packRoot = dirname(manifestPath);
         const contentPath = join(packRoot, "content.json");
-        if (existsSync(contentPath)) inspectContentFile(contentPath, packRoot, state, new Set());
+        if (existsSync(contentPath)) inspectContentPatcherPack(packRoot, catalog);
         else state.failures.count += 1;
       } else {
         state.unsupportedChangeCount += 1;
@@ -149,6 +93,18 @@ export function scanModCompatibility(modsRoot) {
     state.codeModCount += 1;
     if (!SAFE_CODE_MODS.has(uniqueId)) state.unclassifiedCodeModCount += 1;
   }
+  state.unsupportedChangeCount += catalog.unsupportedChangeCount;
+  state.failures.count += catalog.parseFailureCount;
+  for (const change of catalog.changes) {
+    if (change.asset && change.supported && change.target.startsWith("mods/")) continue;
+    const domain = domainForTarget(change.target);
+    state.alteredDomains.add(domain);
+    if (!change.supported || !SUPPORTED_CONTENT_PACK_DOMAINS.has(domain)) state.uncertainDomains.add(domain);
+    else state.supportedDomains.add(domain);
+  }
+  // Unknown targets or unreadable files can affect any consumer; retain explicit global uncertainty.
+  if (state.failures.count || state.unsupportedChangeCount) state.uncertainDomains.add("other");
+  for (const domain of state.uncertainDomains) state.supportedDomains.delete(domain);
   if (state.unclassifiedCodeModCount > 0) state.uncertainDomains.add("other");
   const sortDomains = (values) => [...values].sort((left, right) => DOMAIN_ORDER.indexOf(left) - DOMAIN_ORDER.indexOf(right));
   const uncertain = state.failures.count > 0 || state.unsupportedChangeCount > 0 || state.uncertainDomains.size > 0;

--- a/scripts/mod-consumers.mjs
+++ b/scripts/mod-consumers.mjs
@@ -1,0 +1,18 @@
+// Consume only the additions accepted by the shared Content Patcher reader.
+export function addCatalogEntries(target, additions, diagnostics, domain) {
+  for (const [id, value] of Object.entries(additions || {})) {
+    if (Object.hasOwn(target, id)) {
+      diagnostics.status = "uncertain";
+      diagnostics.supportedDomains = (diagnostics.supportedDomains || []).filter((value) => value !== domain);
+      diagnostics.uncertainDomains = [...new Set([...diagnostics.uncertainDomains, domain])];
+    } else target[id] = value;
+  }
+}
+
+export function npcMetadata(characters) {
+  return Object.fromEntries(Object.entries(characters || {}).map(([id, entry]) => [id, {
+    displayName: entry.DisplayName || id,
+    birthSeason: ["spring", "summer", "fall", "winter"].includes(entry.BirthSeason) ? entry.BirthSeason : null,
+    birthDay: Number.isInteger(entry.BirthDay) && entry.BirthDay >= 1 && entry.BirthDay <= 28 ? entry.BirthDay : null,
+  }]));
+}

--- a/tests/fishing-snapshot.test.mjs
+++ b/tests/fishing-snapshot.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+test("fishing snapshot respects spawn access, skill and uncertain restrictions", () => {
+  const result = spawnSync(process.env.PYTHON || "python", [
+    fileURLToPath(new URL("./fishing_snapshot_test.py", import.meta.url)),
+  ], { encoding: "utf8", windowsHide: true });
+  assert.equal(result.status, 0, result.error?.message || result.stderr || result.stdout);
+});

--- a/tests/fishing_snapshot_test.py
+++ b/tests/fishing_snapshot_test.py
@@ -1,0 +1,87 @@
+"""Synthetic behavioral tests: never read installed assets or player saves."""
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+import xml.etree.ElementTree as ET
+
+# Fishing does not use image rendering. Keep these tests runnable with stdlib
+# Python on CI, independently of the application's optional image dependency.
+sys.modules["PIL"] = types.SimpleNamespace(Image=None)
+spec = importlib.util.spec_from_file_location("snapshot", Path(__file__).parents[1] / "scripts/generate_snapshot.py")
+snapshot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(snapshot)
+
+
+class FishingTests(unittest.TestCase):
+    def brief(self, locations, *, player="", fish_id="Example.Fish", level=3, season="spring", modded=True, extra_catalog=None):
+        root = ET.fromstring('<Save><locations><GameLocation><name>Example.Locked</name></GameLocation></locations></Save>')
+        farmer = ET.fromstring(f'<Farmer>{player}</Farmer>')
+        entry = {"id": f"(O){fish_id}", "name": "Nombre localizado", "verified": True,
+                 "modded": modded, "locations": locations}
+        data = {"fish": {fish_id: "Synthetic/20/mixed/1/5/600 2600/spring/both/0"},
+                "productionCatalog": {"fishing": [entry, *(extra_catalog or [])]}}
+        with tempfile.TemporaryDirectory() as directory:
+            snapshot.GAME_DATA = Path(directory) / "game-data.json"
+            snapshot.GAME_DATA.write_text(json.dumps(data), encoding="utf-8")
+            return snapshot.fishing_brief(root, farmer, season, 1, {"fishing": level})["fish"][0]
+
+    def spawn(self, location, **kwargs):
+        return {"id": location, "verified": True, "minFishingLevel": 0, **kwargs}
+
+    def test_locked_and_unlocked_zones(self):
+        locations = [self.spawn(name) for name in ("Woods", "Sewer", "Desert", "IslandSouth")]
+        self.assertEqual(self.brief(locations)["accessibleLocations"], [])
+        player = ('<hasRustyKey>true</hasRustyKey><mailReceived><string>ccVault</string>'
+                  '<string>willyBoatFixed</string></mailReceived>'
+                  '<items><Item xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Axe">'
+                  '<upgradeLevel>2</upgradeLevel></Item></items>')
+        self.assertEqual(self.brief(locations, player=player)["accessibleLocations"],
+                         ["Secret Woods", "Sewers", "Desert", "Ginger Island Ocean"])
+
+    def test_level_is_per_location(self):
+        fish = self.brief([self.spawn("Beach", minFishingLevel=1), self.spawn("Town", minFishingLevel=10)])
+        self.assertEqual(fish["accessibleLocations"], ["Ocean"])
+        self.assertEqual(fish["minFishingLevel"], 1)
+
+    def test_season_is_per_location(self):
+        fish = self.brief([self.spawn("Beach", season="Summer"), self.spawn("Town", season="Spring")])
+        self.assertEqual(fish["accessibleLocations"], ["Town River"])
+
+    def test_unsupported_rules_never_confirm_routes(self):
+        for rule in ({"unsupportedRules": ["bobberPosition"]}, {"condition": "UNKNOWN"},
+                     {"requireMagicBait": True}, {"ignoreFishDataRequirements": True}, {"verified": False}):
+            with self.subTest(rule=rule):
+                fish = self.brief([self.spawn("Beach", **rule), self.spawn("Town")])
+                self.assertEqual(fish["accessibleLocations"], ["Town River"])
+                self.assertEqual(fish["uncertainLocations"], ["Ocean"])
+                self.assertFalse(fish["verified"])
+
+    def test_serialized_custom_location_does_not_prove_access(self):
+        fish = self.brief([self.spawn("Example.Locked", displayName="Mapa localizado")])
+        self.assertEqual(fish["accessibleLocations"], [])
+        self.assertEqual(fish["uncertainLocations"], ["Mapa localizado"])
+        self.assertFalse(fish["verified"])
+
+    def test_vanilla_fallback_and_legendary_level_are_preserved(self):
+        fish = self.brief([], fish_id="163", modded=False, level=9)
+        self.assertEqual(fish["accessibleLocations"], [])
+        self.assertEqual(fish["minFishingLevel"], 10)
+        self.assertEqual(fish["weather"], "rainy")
+        self.assertTrue(self.brief([], fish_id="163", modded=False, level=10)["accessibleLocations"])
+
+    def test_modified_vanilla_uses_catalog_constraints(self):
+        fish = self.brief([self.spawn("Desert")], fish_id="128")
+        self.assertEqual(fish["locations"], ["Desert"])
+        self.assertEqual(fish["accessibleLocations"], [])
+
+    def test_other_namespaces_cannot_override_fish_identity(self):
+        fish = self.brief([self.spawn("Beach")], extra_catalog=[{"id": "(BC)Example.Fish", "name": "Wrong"}])
+        self.assertEqual(fish["name"], "Nombre localizado")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/mod-compatibility.test.mjs
+++ b/tests/mod-compatibility.test.mjs
@@ -36,7 +36,7 @@ test("a vanilla or SMAPI-default setup remains vanilla-derived", () => {
 test("supported Content Patcher NPC data is identified as mod-aware", () => {
   const files = fixture();
   try {
-    files.addMod("NPC Pack", {
+    const pack = files.addMod("NPC Pack", {
       UniqueID: "Example.Npcs",
       ContentPackFor: { UniqueID: "Pathoschild.ContentPatcher" },
     }, {
@@ -45,6 +45,7 @@ test("supported Content Patcher NPC data is identified as mod-aware", () => {
         { Action: "Load", Target: "Portraits/Example", FromFile: "portrait.png" },
       ],
     });
+    writeFileSync(join(pack, "portrait.png"), Buffer.from("synthetic portrait"));
     const summary = scanModCompatibility(files.root);
     assert.equal(summary.status, "mod-aware");
     assert.deepEqual(summary.alteredDomains, ["npcs"]);
@@ -127,4 +128,150 @@ test("conditional or tokenized crop edits and code mods produce explicit uncerta
   } finally {
     files.cleanup();
   }
+});
+
+const cpManifest = (id) => ({ UniqueID: id, ContentPackFor: { UniqueID: "Pathoschild.ContentPatcher" } });
+
+test("conditional includes identify uncertainty without contributing catalog entries", async () => {
+  const files = fixture();
+  try {
+    const pack = files.addMod("Conditional", cpManifest("Example.Conditional"), { Changes: [
+      { Action: "Include", FromFile: "nested.json", When: { Season: "spring" } },
+    ] });
+    writeFileSync(join(pack, "nested.json"), JSON.stringify({ Changes: [
+      { Action: "EditData", Target: "Data/Crops", Entries: { Seed: { HarvestItemId: "Fruit" } } },
+    ] }));
+    const summary = scanModCompatibility(files.root);
+    assert.equal(summary.status, "uncertain");
+    assert.deepEqual(summary.supportedDomains, []);
+    assert.ok(summary.uncertainDomains.includes("crops"));
+    assert.deepEqual((await buildContentPatcherCatalogOverlay(files.root)).crops, {});
+  } finally { files.cleanup(); }
+});
+
+test("conflicting additions are excluded independently of pack order and qualified ids stay distinct", async () => {
+  for (const reversed of [false, true]) {
+    const files = fixture();
+    try {
+      for (const [index, price] of (reversed ? [20, 10] : [10, 20]).entries())
+        files.addMod(`Pack${index}`, cpManifest(`Example.${index}`), { Changes: [
+          { Action: "EditData", Target: "Data/Objects", Entries: { Shared: { Price: price }, [`${index ? "(BC)" : "(O)"}100`]: { Price: price } } },
+          { Action: "EditData", Target: "Data/Shops", TargetField: ["Shop", "Items"], Entries: { Shared: { ItemId: "Shared", Price: price } } },
+        ] });
+      const overlay = await buildContentPatcherCatalogOverlay(files.root);
+      assert.equal(overlay.objects.Shared, undefined);
+      assert.ok(overlay.objects["(BC)100"]);
+      assert.ok(overlay.objects["(O)100"]);
+      assert.deepEqual(overlay.shopItems.flatMap((entry) => entry.items), []);
+      const summary = scanModCompatibility(files.root);
+      assert.deepEqual(summary.uncertainDomains, ["items"]);
+      assert.deepEqual(summary.supportedDomains, []);
+    } finally { files.cleanup(); }
+  }
+});
+
+test("malformed, tokenized and partial patches never claim NPC support", async () => {
+  const files = fixture();
+  try {
+    files.addMod("Partial", cpManifest("Example.Partial"), { Changes: [
+      { Action: "EditData", Target: "Data/Characters", Entries: { Example: {} }, Fields: { Example: { Age: "Adult" } } },
+      { Action: "EditData", Target: "Data/NPCGiftTastes", Entries: { Example: null } },
+      { Action: "Load", Target: "Portraits/Example", FromFile: "{{Season}}.png" },
+      { Action: "EditData", Target: "Data/Locations", TargetField: ["{{Location}}", "Fish"], Entries: { Fish: {} } },
+      { Action: "EditData", Target: "Data/Buildings", TargetField: "Cost", Entries: { Shed: {} } },
+      { Action: "Include", FromFile: "{{Season}}.json" },
+      null,
+    ] });
+    const summary = scanModCompatibility(files.root);
+    assert.equal(summary.status, "uncertain");
+    assert.deepEqual(summary.supportedDomains, []);
+    assert.ok(summary.uncertainDomains.includes("npcs"));
+    assert.ok(summary.uncertainDomains.includes("other"));
+    const overlay = await buildContentPatcherCatalogOverlay(files.root);
+    assert.deepEqual(overlay.characters, {});
+    assert.deepEqual(overlay.npcGiftTastes, {});
+    assert.deepEqual(overlay.locationFish, []);
+    assert.deepEqual(overlay.buildings, {});
+  } finally { files.cleanup(); }
+});
+
+test("bad included JSON retains valid additions but exposes global uncertainty", async () => {
+  const files = fixture();
+  try {
+    const pack = files.addMod("Broken", cpManifest("Example.Broken"), { Changes: [
+      { Action: "EditData", Target: "Data/Objects", Entries: { Item: { Price: 20 } } },
+      { Action: "Include", FromFile: "broken.json" },
+      { Action: "EditData", Target: "Data/Crops", Entries: { Seed: { HarvestItemId: "Item" } } },
+    ] });
+    writeFileSync(join(pack, "broken.json"), "{ malformed");
+    const summary = scanModCompatibility(files.root);
+    assert.equal(summary.status, "uncertain");
+    assert.equal(summary.parseFailureCount, 1);
+    assert.ok(summary.uncertainDomains.includes("other"));
+    const overlay = await buildContentPatcherCatalogOverlay(files.root);
+    assert.equal(overlay.objects.Item.Price, 20);
+    assert.equal(overlay.crops.Seed.HarvestItemId, "Item");
+  } finally { files.cleanup(); }
+});
+
+test("missing or escaping texture sources are uncertain and never ingested", async () => {
+  const files = fixture();
+  try {
+    files.addMod("Missing", cpManifest("Example.Missing"), { Changes: [
+      { Action: "Load", Target: "Portraits/Example", FromFile: "missing.png" },
+      { Action: "Load", Target: "Mods/Example/Image", FromFile: "../../escape.png" },
+    ] });
+    const summary = scanModCompatibility(files.root);
+    assert.equal(summary.status, "uncertain");
+    assert.deepEqual(summary.supportedDomains, []);
+    const overlay = await buildContentPatcherCatalogOverlay(files.root);
+    assert.deepEqual(overlay.textures, {});
+    assert.deepEqual(overlay.npcTextures, {});
+  } finally { files.cleanup(); }
+});
+
+test("no-mod catalog and diagnostics remain empty", async () => {
+  const files = fixture();
+  try {
+    assert.equal(scanModCompatibility(files.root).status, "vanilla");
+    for (const value of Object.values(await buildContentPatcherCatalogOverlay(files.root)))
+      assert.equal(Object.keys(value).length, 0);
+  } finally { files.cleanup(); }
+});
+
+test("production dictionaries use the same accepted entries as diagnostics", async () => {
+  const files = fixture();
+  try {
+    const targets = {
+      "Data/BigCraftables": "bigCraftables", "Data/Machines": "machines",
+      "Data/FarmAnimals": "farmAnimals", "Data/FishPondData": "fishPondData",
+      "Data/FruitTrees": "fruitTrees", "Data/WildTrees": "wildTrees",
+    };
+    files.addMod("Production", cpManifest("Example.Production"), { Changes: Object.keys(targets).map((target) => ({
+      Action: "EditData", Target: target, Entries: { Example: { Name: "Synthetic" } },
+    })) });
+    const overlay = await buildContentPatcherCatalogOverlay(files.root);
+    for (const key of Object.values(targets)) assert.equal(overlay[key].Example.Name, "Synthetic");
+    const summary = scanModCompatibility(files.root);
+    assert.equal(summary.status, "mod-aware");
+    assert.deepEqual(summary.supportedDomains, ["items", "crops", "fish", "machines", "animals"]);
+  } finally { files.cleanup(); }
+});
+
+test("static includes ingest NPC data and preserve texture target casing", async () => {
+  const files = fixture();
+  try {
+    const pack = files.addMod("NPC", cpManifest("Example.NPC"), { Changes: [{ Action: "Include", FromFile: "npc.json" }] });
+    writeFileSync(join(pack, "portrait.png"), "synthetic");
+    writeFileSync(join(pack, "npc.json"), JSON.stringify({ Changes: [
+      { Action: "EditData", Target: "Data/Characters", Entries: { CustomNPC: { DisplayName: "Custom" } } },
+      { Action: "EditData", Target: "Data/NPCGiftTastes", Entries: { CustomNPC: "Love/24/Like/16/Dislike/80/Hate/390/Neutral/72/" } },
+      { Action: "Load", Target: "Portraits/CustomNPC", FromFile: "portrait.png" },
+    ] }));
+    const overlay = await buildContentPatcherCatalogOverlay(files.root);
+    assert.equal(overlay.characters.CustomNPC.DisplayName, "Custom");
+    assert.ok(overlay.npcGiftTastes.CustomNPC);
+    assert.equal(overlay.npcTextures["Portraits/CustomNPC"], join(pack, "portrait.png"));
+    assert.deepEqual(scanModCompatibility(files.root).supportedDomains, ["npcs"]);
+  } finally { files.cleanup(); }
 });

--- a/tests/mod-consumers.test.mjs
+++ b/tests/mod-consumers.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { addCatalogEntries, npcMetadata } from "../scripts/mod-consumers.mjs";
+
+test("accepted NPC additions preserve text while collisions retain original data", () => {
+  const target = { Existing: "original" };
+  const diagnostic = { status: "mod-aware", uncertainDomains: [] };
+  addCatalogEntries(target, { Existing: "replacement", Added: "new" }, diagnostic, "npcs");
+  assert.deepEqual(target, { Existing: "original", Added: "new" });
+  assert.deepEqual(diagnostic.uncertainDomains, ["npcs"]);
+  assert.equal(diagnostic.status, "uncertain");
+  assert.deepEqual(npcMetadata({ Added: { DisplayName: "[Strings:Unresolved]", BirthSeason: "spring", BirthDay: 3 } }), {
+    Added: { displayName: "[Strings:Unresolved]", birthSeason: "spring", birthDay: 3 },
+  });
+  assert.equal(npcMetadata({ Added: { BirthDay: 40 } }).Added.birthDay, null);
+});
+
+test("mod recipes, buildings and NPCs reach snapshot consumers", () => {
+  const result = spawnSync(process.env.PYTHON || (process.platform === "win32" ? "python" : "python3"), [fileURLToPath(new URL("./mod_consumers_test.py", import.meta.url))], { encoding: "utf8", windowsHide: true });
+  assert.equal(result.status, 0, result.error?.message || result.stderr || result.stdout);
+});

--- a/tests/mod-production-extractor.test.mjs
+++ b/tests/mod-production-extractor.test.mjs
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { calculateMachinePlan } from "../app/planning/machine-engine.mjs";
+import { calculateAnimalPlan } from "../app/planning/animal-engine.mjs";
+import { calculateFishPondPlan } from "../app/planning/pond-engine.mjs";
+import { calculateTappedTreePlan } from "../app/planning/forestry-engine.mjs";
+import { calculateProductionPlan } from "../app/planning/production-engine.mjs";
+
+// Opt-in: game data stays in memory; only synthetic input is written to a temporary directory.
+test("local extractor additions reach production engines without replacing base data", { skip: !process.env.STARDEW_PATH }, () => {
+  const extractor = resolve("tools/StardewDataExtractor/bin/Debug/net8.0/StardewDataExtractor.dll");
+  const read = overlay => JSON.parse(execFileSync("dotnet", [extractor, process.env.STARDEW_PATH, ...(overlay ? [overlay] : [])], { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }));
+  const baseline = read();
+  const directory = mkdtempSync(join(tmpdir(), "companion-synthetic-"));
+  try {
+    const overlay = join(directory, "overlay.json");
+    writeFileSync(overlay, JSON.stringify({
+      objects: { TestInput: { Name: "Synthetic input", Price: 10 }, TestOutput: { Name: "Synthetic output", Price: 50 }, TestFish: { Name: "Synthetic fish", Price: 80, Category: -4, ContextTags: ["synthetic_pond"] }, TestSeed: { Name: "Synthetic seed", Price: 100 } },
+      bigCraftables: { TestMachine: { Name: "Synthetic machine" } },
+      machines: { "(BC)TestMachine": { OutputRules: [{ Id: "fixed", Triggers: [{ Trigger: "ItemPlacedInMachine", RequiredItemId: "(O)TestInput", RequiredCount: 1 }], OutputItem: [{ ItemId: "(O)TestOutput" }], MinutesUntilReady: 1600 }] } },
+      buildings: { TestHouse: { Name: "Synthetic house", BuildCost: 100, MaxOccupants: 4 } },
+      farmAnimals: { TestAnimal: { RequiredBuilding: "TestHouse", PurchasePrice: 100, DaysToMature: 1, DaysToProduce: 1, ProduceItemIds: [{ Id: "fixed", ItemId: "TestOutput" }], DeluxeProduceItemIds: [] } },
+      fishPondData: { TestPond: { RequiredTags: ["synthetic_pond"], Precedence: -100, MaxPopulation: 2, SpawnTime: 1, BaseMinProduceChance: 1, BaseMaxProduceChance: 1, ProducedItems: [{ Id: "fixed", ItemId: "TestOutput", Chance: 1 }] } },
+      fruitTrees: { TestSeed: { Seasons: ["Spring"], Fruit: [{ Id: "fixed", ItemId: "TestOutput", Chance: 1 }] } },
+      wildTrees: { TestTree: { SeedItemId: "TestSeed", GrowthChance: 1, TapItems: [{ Id: "fixed", ItemId: "TestOutput", DaysUntilReady: 1, Chance: 1 }] } },
+    }));
+    const catalog = read(overlay);
+    assert.deepEqual(catalog.crops, baseline.crops);
+    const startDate = { year: 1, season: "spring", day: 1 };
+    const conversion = catalog.artisanMachines.find(item => item.machine.id === "(BC)TestMachine");
+    assert.equal(conversion.verified, true);
+    assert.equal(calculateMachinePlan({ conversion, machineCount: 1, initialInput: 2, existing: true, startDate, durationDays: 4 }).batches, 2);
+    const animal = catalog.farmAnimals.find(item => item.id === "animal:TestAnimal");
+    assert.equal(animal.verified, true);
+    assert.equal(calculateAnimalPlan({ animal, count: 1, existingCount: 1, startDate, durationDays: 4 }).outputs[0].item.id, "(O)TestOutput");
+    const pond = catalog.fishPonds.find(item => item.id === "pond:(O)TestFish");
+    assert.equal(pond.ruleId, "TestPond");
+    assert.ok(calculateFishPondPlan({ pond, pondCount: 1, startPopulation: 2, existing: true, startDate, durationDays: 4 }).scenarios.expected.grossRevenue > 0);
+    const tree = catalog.fruitTrees.find(item => item.id === "(O)TestSeed");
+    assert.equal(tree.verified, false, "missing purchase cost must remain uncertain");
+    const plan = calculateProductionPlan({ producer: { ...tree, outputValue: tree.output.price }, mode: "units", amount: 1, startDate, durationDays: 50 });
+    assert.ok(plan.warnings.includes("unverified-producer-data"));
+    const tapped = catalog.tappedTrees.find(item => item.treeType === "TestTree");
+    assert.equal(tapped.tapItems[0].item.id, "(O)TestOutput");
+    assert.equal(tapped.verified, true);
+    const tappedPlan = calculateTappedTreePlan({ count: 1, days: 4, cycleDays: tapped.tapItems[0].daysUntilReady, existing: true, heavy: false, growthChance: tapped.growthChance, seedCost: tapped.seed.price, equipmentCost: 0, outputPrice: tapped.tapItems[0].item.price });
+    assert.equal(tappedPlan.gross, 200);
+    const unsupported = JSON.parse(readFileSync(overlay, "utf8"));
+    unsupported.machines["(BC)TestMachine"].AdditionalConsumedItems = [{ ItemId: "(BC)TestInput", RequiredCount: 1 }];
+    unsupported.farmAnimals.TestAnimal.ProduceItemIds[0].Condition = "SYNTHETIC_RUNTIME_CONDITION";
+    unsupported.fishPondData.TestPond.ProducedItems[0].Condition = "SYNTHETIC_RUNTIME_CONDITION";
+    unsupported.wildTrees.TestTree.TapItems[0].Chance = 0.5;
+    writeFileSync(overlay, JSON.stringify(unsupported));
+    const uncertain = read(overlay);
+    const uncertainMachine = uncertain.artisanMachines.find(item => item.machine.id === "(BC)TestMachine");
+    assert.equal(uncertainMachine.verified, false, "a big craftable is not an object with the same suffix");
+    assert.equal(uncertainMachine.additionalInputs[0].item.id, "(BC)TestInput");
+    assert.equal(uncertain.overlayDiagnostics.skipped.machines, 1);
+    assert.equal(uncertain.farmAnimals.find(item => item.id === animal.id).verified, false);
+    assert.equal(uncertain.fishPonds.find(item => item.id === pond.id).verified, false);
+    assert.equal(uncertain.tappedTrees.find(item => item.treeType === "TestTree").verified, false);
+    assert.ok(calculateAnimalPlan({ animal: { ...animal, verified: false }, count: 1, startDate, durationDays: 4 }).warnings.includes("unverified-producer-data"));
+    assert.ok(calculateFishPondPlan({ pond: { ...pond, verified: false }, pondCount: 1, startDate, durationDays: 4 }).warnings.includes("unverified-producer-data"));
+  } finally { rmSync(directory, { recursive: true, force: true }); }
+});

--- a/tests/mod_consumers_test.py
+++ b/tests/mod_consumers_test.py
@@ -1,0 +1,36 @@
+import importlib.util
+from pathlib import Path
+import xml.etree.ElementTree as ET
+import sys
+import types
+sys.modules["PIL"] = types.SimpleNamespace(Image=None)
+
+spec = importlib.util.spec_from_file_location("snapshot", Path(__file__).parents[1] / "scripts/generate_snapshot.py")
+snapshot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(snapshot)
+root = ET.fromstring("<SaveGame><player><friendshipData><item><key><string>Example.Npc</string></key><value><Friendship><Points>500</Points></Friendship></value></item></friendshipData></player><locations><GameLocation><name>Farm</name><buildings /></GameLocation></locations></SaveGame>")
+player = root.find("player")
+data = {
+    "moddedCharacters": {"Example.Npc": {"displayName": "Example Person", "birthSeason": "spring", "birthDay": 3}},
+    "cookingRecipes": {"Example Meal": "Example.Ingredient 2/unused/(O)Example.Output 1"},
+    "craftingRecipes": {"Example Machine": "Example.Ingredient 2/unused/(BC)Example.Output 1/true"},
+    "productionCatalog": {"buildings": [
+        {"id": "Example.Building", "name": "Example Building", "money": 100, "materials": [{"id": "(O)Example.Material", "count": 2}], "modded": True, "verified": True},
+        {"id": "Example.Unknown", "name": "Example Unknown", "money": 0, "materials": [], "modded": True, "verified": False},
+    ]},
+}
+plan = snapshot.planning_brief(root, player, root.find("locations"), "spring", 1, 1000, [], data)
+assert plan["friendships"][0]["id"] == "Example.Npc"
+assert plan["friendships"][0]["daysToBirthday"] == 2
+assert plan["friendships"][0]["name"] == "Example Person"
+added = [b for b in plan["buildings"] if b.get("modded")]
+assert len(added) == 2
+assert added[0]["materials"][0]["id"] == "(O)Example.Material"
+assert added[0]["affordable"] is False
+assert added[1]["verified"] is False and added[1]["affordable"] is False
+collections = snapshot.long_term_collection_brief(player, data)
+assert collections["cooking"][0]["id"] == "(O)Example.Output"
+assert collections["crafting"][0]["id"] == "(BC)Example.Output"
+assert collections["crafting"][0]["spriteKind"] == "craftable"
+assert collections["cooking"][0]["learned"] is False
+print("Mod consumer behavioral checks passed.")

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1017,7 +1017,7 @@ test("Friendship planning includes the pet, available gifts, sorting, and Grandp
     /VANILLA_FRIENDSHIP_NPCS = frozenset\(BIRTHDAYS\.values\(\)\)/,
   );
   assert.match(generator, /name not in VANILLA_FRIENDSHIP_NPCS/);
-  assert.match(generator, /"id": name, "name": name/);
+  assert.match(generator, /"id": name, "name": character\.get/);
   assert.match(generator, /"giftsToday": number\(value, "GiftsToday"\)/);
   assert.match(generator, /"pet": pet/);
   assert.match(
@@ -1094,14 +1094,9 @@ test("friendship artwork is extracted privately from the local game", async () =
   assert.match(extractor, /"Leah", "Leo", "Lewis"/);
   assert.match(extractor, /public\/assets\/characters\/\$\{name\}\.png/);
   assert.match(extractor, /public\/assets\/portraits\/\$\{name\}\.png/);
-  assert.match(extractor, /findContentPacks\(modsRoot\)/);
-  assert.match(extractor, /import JSON5 from "json5"/);
-  assert.match(extractor, /\^\(Characters\|Portraits\)/);
-  assert.match(extractor, /gameData\.moddedCharacters = moddedNpcs\.metadata/);
-  assert.match(
-    extractor,
-    /Object\.assign\(gameData\.giftTastes, moddedNpcs\.giftTastes\)/,
-  );
+  assert.match(extractor, /contentPatcherOverlay\.npcTextures/);
+  assert.match(extractor, /gameData\.moddedCharacters = npcMetadata/);
+  assert.match(extractor, /addCatalogEntries\(gameData\.giftTastes/);
   assert.match(desktop, /"characters", "Abigail\.png"/);
   assert.match(desktop, /"portraits", "Abigail\.png"/);
 });
@@ -1187,8 +1182,8 @@ test("modded fishing uses the local structured catalog and preserves uncertain r
   assert.match(extractor, /Dictionary<string, LocationData> locations/);
   assert.match(generator, /catalog_fish = \{/);
   assert.match(generator, /catalog_entry\.get\("artworkUrl"\)/);
-  assert.match(generator, /"verified": bool\(catalog_entry\.get/);
-  assert.match(page, /fish\.modded && !fish\.verified/);
+  assert.match(generator, /"verified":/);
+  assert.match(page, /fish\.verified === false/);
   assert.match(page, /<ModdedItemArtwork url=\{fish\.artworkUrl\}/);
 });
 
@@ -1696,8 +1691,8 @@ test("Farm, Plan, and Progress share storage, goals, history, and completion dat
   assert.match(extractor, /Strings\/Furniture\.xnb/);
   assert.match(extractor, /Data\/Boots\.xnb/);
   assert.match(extractor, /Data\/hats\.xnb/);
-  assert.match(extractor, /catalogVersion: 11/);
-  assert.match(desktop, /catalogVersion !== 11/);
+  assert.match(extractor, /catalogVersion: 12/);
+  assert.match(desktop, /catalogVersion !== 12/);
   assert.match(extractor, /game-localization\.\$\{catalogLanguage\}\.json/);
   assert.match(extractor, /const activeLocalization = gameLocalizationCatalogs\.en/);
   assert.match(extractor, /Data\/Achievements\.xnb/);

--- a/tools/StardewDataExtractor/Program.cs
+++ b/tools/StardewDataExtractor/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework.Content;
 using StardewValley.GameData.BigCraftables;
 using StardewValley.GameData.Buildings;
 using StardewValley.GameData.Crops;
+using StardewValley.GameData.Characters;
 using StardewValley.GameData.FruitTrees;
 using StardewValley.GameData.FarmAnimals;
 using StardewValley.GameData.FishPonds;
@@ -38,6 +39,7 @@ static class GameCatalogReader
     public static string Read(string contentRoot, string? overlayPath)
     {
         using var content = new ContentManager(new EmptyServices(), contentRoot);
+        var characterIds = content.Load<Dictionary<string, CharacterData>>("Data/Characters").Keys.ToArray();
         Dictionary<string, CropData> crops = content.Load<Dictionary<string, CropData>>("Data/Crops");
         Dictionary<string, ObjectData> objects = content.Load<Dictionary<string, ObjectData>>("Data/Objects");
         Dictionary<string, FruitTreeData> fruitTrees = content.Load<Dictionary<string, FruitTreeData>>("Data/FruitTrees");
@@ -59,6 +61,9 @@ static class GameCatalogReader
         int skippedRecipeEdits = 0;
         int skippedBuildingEdits = 0;
         int skippedLocationEdits = 0;
+        int skippedMachineEdits = 0, skippedAnimalEdits = 0, skippedPondEdits = 0, skippedTreeEdits = 0;
+        var moddedMachineIds = new HashSet<string>();
+        var moddedBuildingIds = new HashSet<string>();
         var moddedFishIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         if (!string.IsNullOrWhiteSpace(overlayPath) && File.Exists(overlayPath))
@@ -71,6 +76,30 @@ static class GameCatalogReader
             {
                 try { return entry.Deserialize<T>(jsonOptions); }
                 catch { return null; }
+            }
+            int AddEntries<T>(Dictionary<string, T> target, Dictionary<string, JsonElement>? entries, HashSet<string>? added = null) where T : class
+            {
+                int skipped = 0;
+                foreach ((string id, JsonElement entry) in entries ?? new())
+                {
+                    T? value = DeserializeEntry<T>(entry);
+                    if (target.ContainsKey(id) || value is null) { skipped++; continue; }
+                    target[id] = value;
+                    added?.Add(id);
+                }
+                return skipped;
+            }
+            skippedMachineEdits += AddEntries(bigCraftables, overlay?.BigCraftables);
+            skippedMachineEdits += AddEntries(machines, overlay?.Machines, moddedMachineIds);
+            skippedAnimalEdits += AddEntries(farmAnimals, overlay?.FarmAnimals);
+            skippedTreeEdits += AddEntries(fruitTrees, overlay?.FruitTrees);
+            skippedTreeEdits += AddEntries(wildTrees, overlay?.WildTrees);
+            foreach ((string id, JsonElement entry) in overlay?.FishPondData ?? new())
+            {
+                FishPondData? value = DeserializeEntry<FishPondData>(entry);
+                if (value is null || fishPondRules.Any(rule => rule.Id == id)) { skippedPondEdits++; continue; }
+                value.Id = id;
+                fishPondRules.Add(value);
             }
             foreach ((string id, JsonElement entry) in overlay?.Objects ?? new())
             {
@@ -103,13 +132,13 @@ static class GameCatalogReader
             {
                 if (buildings.ContainsKey(id)) { skippedBuildingEdits += 1; continue; }
                 BuildingData? value = DeserializeEntry<BuildingData>(entry);
-                if (value is not null) buildings[id] = value; else skippedBuildingEdits += 1;
+                if (value is not null) { buildings[id] = value; moddedBuildingIds.Add(id); } else skippedBuildingEdits += 1;
             }
             foreach ((string id, JsonElement entry) in overlay?.Locations ?? new())
             {
                 if (locations.ContainsKey(id)) { skippedLocationEdits += 1; continue; }
                 LocationData? value = DeserializeEntry<LocationData>(entry);
-                if (value is not null) locations[id] = value; else skippedLocationEdits += 1;
+                if (value is not null) { locations[id] = value; foreach (SpawnFishData spawn in value.Fish ?? new()) if (!string.IsNullOrWhiteSpace(spawn.ItemId)) moddedFishIds.Add(Unqualify(spawn.ItemId)); } else skippedLocationEdits += 1;
             }
             foreach (LocationFishOverlay addition in overlay?.LocationFish ?? new())
             {
@@ -121,6 +150,7 @@ static class GameCatalogReader
                     if (value is null) { skippedLocationEdits += 1; continue; }
                     if (location.Fish.Any(item => item.Id == value.Id)) { skippedLocationEdits += 1; continue; }
                     location.Fish.Add(value);
+                    if (!string.IsNullOrWhiteSpace(value.ItemId)) moddedFishIds.Add(Unqualify(value.ItemId));
                 }
             }
             foreach (ShopItemOverlay addition in overlay?.ShopItems ?? new())
@@ -143,7 +173,7 @@ static class GameCatalogReader
             int close = id.IndexOf(')');
             return close >= 0 ? id[(close + 1)..] : id;
         }
-        ObjectData? ObjectFor(string id) => objects.GetValueOrDefault(Unqualify(id));
+        ObjectData? ObjectFor(string id) => id.StartsWith('(') && !id.StartsWith("(O)") ? null : objects.GetValueOrDefault(Unqualify(id));
         int PurchasePriceFor(ShopItemData item)
         {
             if (!string.IsNullOrWhiteSpace(item.TradeItemId)) return 0;
@@ -181,6 +211,17 @@ static class GameCatalogReader
                 .ToArray();
         }
 
+        static string[] UnsupportedSpawnRules(SpawnFishData spawn)
+        {
+            var reasons = new List<string>();
+            if (!string.IsNullOrWhiteSpace(spawn.Condition)) reasons.Add("condition");
+            if (!string.IsNullOrWhiteSpace(spawn.FishAreaId) || spawn.BobberPosition is not null || spawn.PlayerPosition is not null) reasons.Add("position");
+            if (spawn.MinDistanceFromShore > 0 || spawn.MaxDistanceFromShore >= 0) reasons.Add("shore-distance");
+            if (spawn.CatchLimit > 0 || spawn.IsBossFish) reasons.Add("catch-limit");
+            if (spawn.RequireMagicBait || spawn.IgnoreFishDataRequirements) reasons.Add("bait-or-requirements");
+            if (spawn.RandomItemId?.Count > 0 || spawn.ChanceModifiers?.Count > 0 || spawn.Chance <= 0) reasons.Add("spawn-rules");
+            return reasons.ToArray();
+        }
         var fishingCatalog = fish.Select(pair =>
         {
             string[] parts = pair.Value.Split('/');
@@ -199,7 +240,11 @@ static class GameCatalogReader
                         fishAreaId = spawn.FishAreaId,
                         minFishingLevel = spawn.MinFishingLevel,
                         condition = spawn.Condition,
-                        verified = string.IsNullOrWhiteSpace(spawn.Condition) && spawn.RandomItemId?.Count is not > 0,
+                        season = spawn.Season?.ToString().ToLowerInvariant(),
+                        requireMagicBait = spawn.RequireMagicBait,
+                        ignoreFishDataRequirements = spawn.IgnoreFishDataRequirements,
+                        unsupportedRules = UnsupportedSpawnRules(spawn),
+                        verified = UnsupportedSpawnRules(spawn).Length == 0,
                     }))
                 .ToArray();
             int.TryParse(parts.ElementAtOrDefault(1), out int difficulty);
@@ -324,7 +369,7 @@ static class GameCatalogReader
                 yield = new { min = 1, expected = 1, max = 1 },
                 space = FruitTreeClearanceTiles,
                 clearance = FruitTreeClearanceTiles,
-                verified = primaryFruit is not null && fruit is not null && fruit.Price > 0 && purchasePrice > 0,
+                verified = primaryFruit is not null && fruit is not null && fruit.Price > 0 && purchasePrice > 0 && pair.Value.Fruit.Count == 1 && string.IsNullOrWhiteSpace(primaryFruit.Condition) && primaryFruit.RandomItemId?.Count is not > 0 && primaryFruit.Chance >= 1 && primaryFruit.Season is null,
             };
         }).ToArray();
 
@@ -359,6 +404,7 @@ static class GameCatalogReader
             {
                 id = $"wild-tree:{pair.Key}",
                 treeType = pair.Key,
+                verified = pair.Value.TapItems.Count == 1 && pair.Value.TapItems.All(item => string.IsNullOrWhiteSpace(item.Condition) && item.RandomItemId?.Count is not > 0 && item.Chance >= 1 && item.PreviousItemId?.Count is not > 0 && item.DaysUntilReadyModifiers?.Count is not > 0),
                 seed = DescribeItem(pair.Value.SeedItemId),
                 growthChance = pair.Value.GrowthChance,
                 fertilizedGrowthChance = pair.Value.FertilizedGrowthChance,
@@ -416,11 +462,12 @@ static class GameCatalogReader
 
         var supportedMachineNames = new HashSet<string>(new[] { "Keg", "Preserves Jar", "Dehydrator", "Fish Smoker", "Cheese Press", "Mayonnaise Machine", "Loom" });
         var artisanMachines = new List<object>();
+        var verifiedModMachines = new HashSet<string>();
         foreach ((string machineId, MachineData machineData) in machines)
         {
             string unqualifiedMachineId = Unqualify(machineId);
             BigCraftableData? machine = bigCraftables.GetValueOrDefault(unqualifiedMachineId);
-            if (machine is null || !supportedMachineNames.Contains(machine.Name)) continue;
+            if (machine is null || (!supportedMachineNames.Contains(machine.Name) && !moddedMachineIds.Contains(machineId))) continue;
             foreach ((string rawInputId, ObjectData inputData) in objects)
             {
                 string inputId = QualifyObject(rawInputId);
@@ -439,7 +486,18 @@ static class GameCatalogReader
                     .Select(item => new { item = DescribeItem(item.ItemId), quantity = Math.Max(1, item.RequiredCount) }).ToArray();
                 int additionalInputCost = (machineData.AdditionalConsumedItems ?? new List<MachineItemAdditionalConsumedItems>())
                     .Sum(item => (ObjectFor(item.ItemId)?.Price ?? 0) * Math.Max(1, item.RequiredCount));
+                bool missingAdditionalInputs = (machineData.AdditionalConsumedItems ?? new()).Any(item => ObjectFor(item.ItemId) is not { Price: > 0 });
                 bool hasUnmodeledModifiers = outputRule.PriceModifiers?.Count > 0 || outputRule.StackModifiers?.Count > 0 || outputRule.QualityModifiers?.Count > 0;
+                bool verified = inputData.Price > 0 && outputData.Price > 0 && !hasUnmodeledModifiers && !missingAdditionalInputs && outputRule.RandomItemId?.Count is not > 0 && rule.OutputItem?.Count == 1 && (rule.MinutesUntilReady > 0 || rule.DaysUntilReady > 0);
+                if (moddedMachineIds.Contains(machineId))
+                {
+                    // Only deterministic fixed input/output additions are modeled. Runtime
+                    // callbacks, alternative rules and custom query logic stay uncertain.
+                    verified &= machineData.OutputRules?.Count == 1 && rule.Triggers?.Count == 1
+                        && trigger.RequiredItemId == inputId && string.IsNullOrWhiteSpace(trigger.Condition)
+                        && outputRule.CustomData?.Count is not > 0 && !rule.RecalculateOnCollect;
+                    if (verified) verifiedModMachines.Add(machineId);
+                }
                 artisanMachines.Add(new
                 {
                     id = $"machine:{machineId}:{rule.Id}:{inputId}",
@@ -461,10 +519,12 @@ static class GameCatalogReader
                     artisanEligible = outputData.Category == GameObject.artisanGoodsCategory,
                     additionalInputs,
                     additionalInputCost,
-                    verified = inputData.Price > 0 && outputData.Price > 0 && !hasUnmodeledModifiers,
+                    verified,
                 });
             }
         }
+
+        skippedMachineEdits += moddedMachineIds.Count(id => !verifiedModMachines.Contains(id));
 
         // Casks use an output method instead of a normal item query. Preserve the
         // exact input identity (including flavored wine) and expose the local
@@ -523,6 +583,7 @@ static class GameCatalogReader
             return new
             {
                 id = $"animal:{pair.Key}",
+                verified = requiredBuildingData is not null && pair.Value.ProduceItemIds.Count == 1 && pair.Value.DeluxeProduceItemIds.Count <= 1 && pair.Value.ProduceItemIds.Concat(pair.Value.DeluxeProduceItemIds).All(item => string.IsNullOrWhiteSpace(item.Condition) && ObjectFor(item.ItemId) is { Price: > 0 }) && string.IsNullOrWhiteSpace(pair.Value.UnlockCondition) && pair.Value.ProduceItemIds.All(item => item.MinimumFriendship <= 0),
                 name = pair.Key,
                 texture = pair.Value.Texture,
                 pair.Value.SpriteWidth,
@@ -562,6 +623,7 @@ static class GameCatalogReader
                 return new
                 {
                     id = $"pond:{fishId}",
+                    verified = rule.ProducedItems.Count > 0 && rule.ProducedItems.All(item => string.IsNullOrWhiteSpace(item.Condition) && item.RandomItemId?.Count is not > 0 && ObjectFor(item.ItemId) is { Price: > 0 }),
                     fish = DescribeItem(fishId),
                     processedRoe = DescribeItem(fishId == "(O)698" ? "(O)445" : "(O)447"),
                     ruleId = rule.Id,
@@ -586,8 +648,16 @@ static class GameCatalogReader
             .Where(item => item is not null)
             .ToArray();
 
+        var buildingCatalog = buildings.Select(pair => new
+        {
+            id = pair.Key, name = pair.Value.Name, money = pair.Value.BuildCost,
+            materials = (pair.Value.BuildMaterials ?? new()).Select(item => new { id = QualifyObject(item.ItemId), name = ObjectFor(item.ItemId)?.Name, count = item.Amount }).ToArray(),
+            buildDays = pair.Value.BuildDays, prerequisite = pair.Value.BuildingToUpgrade,
+            condition = pair.Value.BuildCondition, modded = moddedBuildingIds.Contains(pair.Key),
+            verified = string.IsNullOrWhiteSpace(pair.Value.BuildCondition) && pair.Value.BuildCost >= 0 && (pair.Value.BuildMaterials ?? new()).All(item => ObjectFor(item.ItemId) is not null && item.Amount > 0),
+        }).ToArray();
         return JsonSerializer.Serialize(
-            new { catalogVersion = 7, source = "local-game", crops = cropCatalog, fruitTrees = treeCatalog, fertilizers = fertilizerCatalog, tappedTrees = tappedTreeCatalog, mushroomLogs = mushroomLogRules, mushroomLogOutputs, forestryEquipment, artisanMachines, farmAnimals = animalCatalog, fishPonds = pondCatalog, fishing = fishingCatalog, feedUnitCost = PurchasePrice("(O)178"), overlayDiagnostics = new { skipped = new { items = skippedObjectEdits + skippedShopEdits, crops = skippedCropEdits, fish = skippedFishEdits, recipes = skippedRecipeEdits, buildings = skippedBuildingEdits, locations = skippedLocationEdits } } },
+            new { catalogVersion = 8, source = "local-game", characterIds, buildings = buildingCatalog, crops = cropCatalog, fruitTrees = treeCatalog, fertilizers = fertilizerCatalog, tappedTrees = tappedTreeCatalog, mushroomLogs = mushroomLogRules, mushroomLogOutputs, forestryEquipment, artisanMachines, farmAnimals = animalCatalog, fishPonds = pondCatalog, fishing = fishingCatalog, feedUnitCost = PurchasePrice("(O)178"), overlayDiagnostics = new { skipped = new { items = skippedObjectEdits + skippedShopEdits, crops = skippedCropEdits + skippedTreeEdits, fish = skippedFishEdits + skippedPondEdits, recipes = skippedRecipeEdits, buildings = skippedBuildingEdits, locations = skippedLocationEdits, machines = skippedMachineEdits, animals = skippedAnimalEdits } } },
             new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase }
         );
     }
@@ -599,6 +669,12 @@ static class GameCatalogReader
 
     private sealed class CatalogOverlay
     {
+        public Dictionary<string, JsonElement> BigCraftables { get; set; } = new();
+        public Dictionary<string, JsonElement> Machines { get; set; } = new();
+        public Dictionary<string, JsonElement> FarmAnimals { get; set; } = new();
+        public Dictionary<string, JsonElement> FishPondData { get; set; } = new();
+        public Dictionary<string, JsonElement> FruitTrees { get; set; } = new();
+        public Dictionary<string, JsonElement> WildTrees { get; set; } = new();
         public Dictionary<string, JsonElement> Objects { get; set; } = new();
         public Dictionary<string, JsonElement> Crops { get; set; } = new();
         public Dictionary<string, string> Fish { get; set; } = new();


### PR DESCRIPTION
## Changes
Align Content Patcher diagnostics with the catalog actually consumed, reject conflicting additions, and evaluate fishing access and levels per spawn. Add safe local production overlays and connect added recipes, buildings and NPCs to snapshot consumers. Unsupported rules retain explicit uncertainty; MOD_COMPATIBILITY.md documents the boundaries.

## Validation
- Public safety and ESLint passed.
- TypeScript and local C# extractor build passed.
- npm test: 141 passed, 1 opt-in local integration test skipped.
- Opt-in real extractor test passed separately with synthetic overlays; no extracted content or private saves are committed.
- User desktop acceptance testing remains pending; this is a development integration, not a release.

Addresses #80, #81, #82, #83; part of #14. Recipe collection progress is supported; arbitrary ingredient/unlock evaluation and custom map runtime behavior remain explicitly uncertain.
