### PR TITLE
refactor(dashboard): isolate navigation and farm canvas lifecycle

### DIFF
--- a/app/dashboard/README.md
+++ b/app/dashboard/README.md
@@ -5,7 +5,7 @@
 - `snapshot-types.ts` defines saved/local data contracts. `ui-types.ts` holds view state and presentation contracts. Production catalog contracts live in `app/planning/production-types.ts`, independently of the calculator component.
 - `identity.ts`, `game-names.ts`, `formatting.ts` and `selectors.ts` provide shared identity, localization, formatting and reconciliation helpers. `farm-model.ts` reconciles construction proposals without React or canvas.
 - `fishing-view.tsx`, `planning-view.tsx`, `today-view.tsx`, `progress-view.tsx` and `live-view.tsx` own their respective views.
-- `farm-rendering.tsx` owns canvas helpers and interior rendering. `artwork.tsx`, `storage.tsx` and `ui.tsx` own reusable artwork, storage dialogs and controls.
+- `use-dashboard-navigation.ts` owns section history and desktop/mouse/keyboard navigation subscriptions. `use-farm-canvas.ts` owns farm drawing and redraw dependencies. `farm-rendering.tsx` owns canvas helpers and interior rendering. `artwork.tsx`, `storage.tsx` and `ui.tsx` own reusable artwork, storage dialogs and controls.
 
 Imports flow from the page to features and from features to shared modules. Shared modules must not import feature views or the page. A test checks the module graph, including type dependencies, for cycles.
 

--- a/app/dashboard/use-dashboard-navigation.ts
+++ b/app/dashboard/use-dashboard-navigation.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ActiveView, AppNavigationTarget, DesktopUpdates } from "./ui-types";
+
+export function useDashboardNavigation() {
+  const [activeView, setActiveView] = useState<ActiveView>(() => {
+    if (typeof window === "undefined") return "map";
+    const saved =
+      window.localStorage.getItem("stardew-tool-active-view") ||
+      window.localStorage.getItem("aincrad-active-view");
+    return saved === "map" ||
+      saved === "growth" ||
+      saved === "achievements" ||
+      saved === "farm" ||
+      saved === "agenda" ||
+      saved === "fishing" ||
+      saved === "planning"
+      ? saved
+      : "map";
+  });
+
+  const activeViewRef = useRef(activeView);
+
+  const navigationBackRef = useRef<AppNavigationTarget[]>([]);
+
+  const navigationForwardRef = useRef<AppNavigationTarget[]>([]);
+
+  const lastHardwareNavigationRef = useRef({ direction: "", at: 0 });
+
+  const [navigationAvailability, setNavigationAvailability] = useState({ back: false, forward: false });
+
+  const currentNavigationTarget = useCallback((): AppNavigationTarget => {
+    const view = activeViewRef.current;
+    if (view === "farm")
+      return { view, section: window.localStorage.getItem("stardew-tool-farm-section") || "crops" };
+    if (view === "planning")
+      return { view, section: window.localStorage.getItem("stardew-tool-plan-section") || "community" };
+    return { view };
+  }, []);
+
+  const applyNavigationTarget = useCallback((target: AppNavigationTarget) => {
+    activeViewRef.current = target.view;
+    if (target.view === "growth" || target.view === "achievements")
+      window.localStorage.setItem("stardew-tool-progress-section", target.view);
+    if ((target.view === "farm" || target.view === "planning") && target.section) {
+      const mode = target.view === "farm" ? "farm" : "plan";
+      window.localStorage.setItem(`stardew-tool-${mode}-section`, target.section);
+      window.dispatchEvent(new CustomEvent("stardew:open-planning-section", {
+        detail: { mode, section: target.section },
+      }));
+    }
+    setActiveView(target.view);
+  }, []);
+
+  const navigateTo = useCallback((target: AppNavigationTarget) => {
+    const current = currentNavigationTarget();
+    if (current.view === target.view && current.section === target.section) return;
+    navigationBackRef.current.push(current);
+    navigationForwardRef.current = [];
+    applyNavigationTarget(target);
+    setNavigationAvailability({ back: true, forward: false });
+  }, [applyNavigationTarget, currentNavigationTarget]);
+
+  const navigateHistory = useCallback((direction: "back" | "forward") => {
+    const source = direction === "back" ? navigationBackRef : navigationForwardRef;
+    const destination = direction === "back" ? navigationForwardRef : navigationBackRef;
+    const target = source.current.pop();
+    if (!target) return;
+    destination.current.push(currentNavigationTarget());
+    applyNavigationTarget(target);
+    setNavigationAvailability({
+      back: navigationBackRef.current.length > 0,
+      forward: navigationForwardRef.current.length > 0,
+    });
+  }, [applyNavigationTarget, currentNavigationTarget]);
+
+  const navigateHardwareHistory = useCallback((direction: "back" | "forward") => {
+    const now = performance.now();
+    const previous = lastHardwareNavigationRef.current;
+    if (previous.direction === direction && now - previous.at < 120) return;
+    lastHardwareNavigationRef.current = { direction, at: now };
+    navigateHistory(direction);
+  }, [navigateHistory]);
+
+  useEffect(() => {
+    window.localStorage.setItem("stardew-tool-active-view", activeView);
+  }, [activeView]);
+
+  useEffect(() => {
+    const desktop = (window as Window & { stardewDesktop?: DesktopUpdates })
+      .stardewDesktop;
+    return desktop?.onNavigateHistory?.(navigateHardwareHistory);
+  }, [navigateHardwareHistory]);
+
+  useEffect(() => {
+    const mouseHistoryShortcut = (event: MouseEvent) => {
+      if (event.button !== 3 && event.button !== 4) return;
+      event.preventDefault();
+      navigateHardwareHistory(event.button === 3 ? "back" : "forward");
+    };
+    const preventNativeHistory = (event: MouseEvent) => {
+      if (event.button === 3 || event.button === 4) event.preventDefault();
+    };
+    window.addEventListener("mousedown", mouseHistoryShortcut, true);
+    window.addEventListener("auxclick", preventNativeHistory, true);
+    return () => {
+      window.removeEventListener("mousedown", mouseHistoryShortcut, true);
+      window.removeEventListener("auxclick", preventNativeHistory, true);
+    };
+  }, [navigateHardwareHistory]);
+
+  useEffect(() => {
+    const historyShortcut = (event: KeyboardEvent) => {
+      if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+      event.preventDefault();
+      navigateHistory(event.key === "ArrowLeft" ? "back" : "forward");
+    };
+    window.addEventListener("keydown", historyShortcut);
+    return () => window.removeEventListener("keydown", historyShortcut);
+  }, [navigateHistory]);
+  return { activeView, navigateTo, navigateHistory, navigationAvailability };
+}

--- a/app/dashboard/use-farm-canvas.ts
+++ b/app/dashboard/use-farm-canvas.ts
@@ -1,0 +1,393 @@
+"use client";
+
+import { useCallback, useEffect, type RefObject } from "react";
+import type { Snapshot, Tile, Suggestion } from "./snapshot-types";
+import type { ProposalState, ActiveView } from "./ui-types";
+import { TILE, sprite, cropSpriteSource, drawBuildingSprite, tools } from "./farm-rendering";
+
+export type FarmCanvasOptions = {
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  base: HTMLImageElement | null;
+  hover: Tile | null;
+  mapData: Snapshot | null;
+  localSuggestions: Suggestion[];
+  movingProposalId: string | null;
+  proposalEditMode: boolean;
+  proposalStates: ProposalState[];
+  showBlocked: boolean;
+  showGrid: boolean;
+  showProduction: boolean;
+  showState: boolean;
+  showSuggestions: boolean;
+  sprites: Record<string, HTMLImageElement>;
+  tool: string;
+  activeView: ActiveView;
+  mapLocation: string;
+};
+
+export function useFarmCanvas({ canvasRef, base, hover, mapData, localSuggestions, movingProposalId, proposalEditMode, proposalStates, showBlocked, showGrid, showProduction, showState, showSuggestions, sprites, tool, activeView, mapLocation }: FarmCanvasOptions) {
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !mapData || !base) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(base, 0, 0);
+
+    if (mapData.farmType === 0 && (mapData.grandpa.actualCandles || 0) > 0) {
+      const candleTiles = [
+        [7.65, 8.15],
+        [8.15, 7.55],
+        [8.85, 7.55],
+        [9.35, 8.15],
+      ];
+      candleTiles
+        .slice(0, mapData.grandpa.actualCandles)
+        .forEach(([x, y]) => {
+          ctx.fillStyle = "#8b4a20";
+          ctx.fillRect(x * TILE, y * TILE, 2, 5);
+          ctx.fillStyle = "#ffd65a";
+          ctx.fillRect(x * TILE - 1, y * TILE - 4, 4, 4);
+          ctx.fillStyle = "#fff4a0";
+          ctx.fillRect(x * TILE, y * TILE - 3, 2, 2);
+        });
+    }
+
+    if (showBlocked) {
+      ctx.fillStyle = "rgba(72, 38, 76, .26)";
+      for (const [x, y] of mapData.map.blocked)
+        ctx.fillRect(x * TILE, y * TILE, TILE, TILE);
+    }
+
+    if (showState) {
+      const tall: { bottom: number; paint: () => void }[] = [];
+      for (const feature of mapData.terrain) {
+        const px = feature.x * TILE,
+          py = feature.y * TILE;
+        if (feature.kind === "HoeDirt") {
+          const soilOffset = feature.watered ? 128 : 0;
+          sprite(
+            ctx,
+            sprites.hoeDirt,
+            [soilOffset + 16, 0, 32, 32],
+            [px, py, 16, 16],
+          );
+          if (feature.crop && feature.cropRow !== undefined)
+            tall.push({
+              bottom: py + TILE,
+              paint: () => {
+                const phase = feature.dead
+                  ? 6
+                  : Math.min(feature.phase || 0, 5);
+                sprite(
+                  ctx,
+                  sprites.crops,
+                  cropSpriteSource(feature.cropRow!, phase),
+                  [px, py - 16],
+                  Boolean(feature.flip),
+                );
+              },
+            });
+        } else if (feature.kind === "Grass") {
+          const variant = Math.abs(feature.x * 17 + feature.y * 31) % 3;
+          tall.push({
+            bottom: py + TILE,
+            paint: () =>
+              sprite(
+                ctx,
+                sprites.grass,
+                [variant * 15, 0, 15, 20],
+                [px, py - 4],
+              ),
+          });
+        } else if (feature.kind === "Tree") {
+          const tree = sprites[feature.treeType || "Oak"] || sprites.Oak;
+          tall.push({
+            bottom: py + TILE,
+            paint: () => {
+              const stage = feature.stage || 0;
+              if (feature.stump && stage >= 5)
+                sprite(ctx, tree, [16, 96, 32, 32], [px - 8, py - 16]);
+              else if (stage >= 5)
+                sprite(ctx, tree, [0, 0, 48, 96], [px - 16, py - 80]);
+              else if (stage === 4)
+                sprite(ctx, tree, [0, 96, 16, 32], [px, py - 16]);
+              else if (stage === 3)
+                sprite(ctx, tree, [32, 128, 16, 16], [px, py]);
+              else {
+                const sourceX = stage === 0 ? 48 : stage === 1 ? 0 : 16;
+                sprite(ctx, tree, [sourceX, 128, 16, 16], [px, py]);
+              }
+              if (feature.fertilized && stage < 5) {
+                ctx.strokeStyle = "#ffe878";
+                ctx.strokeRect(px + 1.5, py + 1.5, 13, 13);
+              }
+            },
+          });
+        } else if (feature.kind === "FruitTree") {
+          tall.push({
+            bottom: py + TILE,
+            paint: () => {
+              const row = Math.max(
+                0,
+                Math.min(8, Number(feature.treeId || 628) - 628),
+              );
+              const slot = Math.min(feature.stage || 0, 4);
+              sprite(
+                ctx,
+                sprites.fruitTrees,
+                [slot * 48, row * 80, 48, 80],
+                [px - 16, py - 64],
+              );
+            },
+          });
+        }
+      }
+
+      for (const object of mapData.objects) {
+        const index = Number(object.id);
+        if (!Number.isFinite(index)) continue;
+        const px = object.x * TILE,
+          py = object.y * TILE;
+        tall.push({
+          bottom: py + TILE,
+          paint: () => {
+            if (object.big)
+              sprite(
+                ctx,
+                sprites.craftables,
+                [(index % 8) * 16, Math.floor(index / 8) * 32, 16, 32],
+                [px, py - 16],
+              );
+            else
+              sprite(
+                ctx,
+                sprites.objects,
+                [(index % 24) * 16, Math.floor(index / 24) * 16, 16, 16],
+                [px, py],
+              );
+          },
+        });
+      }
+
+      for (const clump of mapData.clumps) {
+        tall.push({
+          bottom: (clump.y + clump.height) * TILE,
+          paint: () => {
+            const index = Number(clump.id);
+            for (let y = 0; y < clump.height; y++)
+              for (let x = 0; x < clump.width; x++) {
+                const part = index + y * 24 + x;
+                sprite(
+                  ctx,
+                  sprites.objects,
+                  [(part % 24) * 16, Math.floor(part / 24) * 16, 16, 16],
+                  [(clump.x + x) * TILE, (clump.y + y) * TILE],
+                );
+              }
+          },
+        });
+      }
+
+      for (const building of mapData.buildings) {
+        tall.push({
+          bottom: (building.y + building.height) * TILE,
+          paint: () => {
+            const px = building.x * TILE,
+              py = building.y * TILE;
+            if (!drawBuildingSprite(ctx, sprites, building)) {
+              ctx.fillStyle = "rgba(116,82,154,.35)";
+              ctx.fillRect(
+                px,
+                py,
+                building.width * TILE,
+                building.height * TILE,
+              );
+            }
+            if ((building.daysOfConstructionLeft || 0) > 0) {
+              ctx.fillStyle = "rgba(240, 167, 55, .2)";
+              ctx.strokeStyle = "#ffd166";
+              ctx.lineWidth = 2;
+              ctx.setLineDash([5, 3]);
+              ctx.fillRect(
+                px,
+                py,
+                building.width * TILE,
+                building.height * TILE,
+              );
+              ctx.strokeRect(
+                px + 1,
+                py + 1,
+                building.width * TILE - 2,
+                building.height * TILE - 2,
+              );
+              ctx.setLineDash([]);
+            }
+          },
+        });
+      }
+      tall
+        .sort((a, b) => a.bottom - b.bottom)
+        .forEach((entity) => entity.paint());
+
+      if (showProduction) {
+        for (const object of mapData.objects.filter(
+          (item) => item.ready || item.processing,
+        )) {
+          const cx = object.x * TILE + 12,
+            cy = object.y * TILE + 3;
+          ctx.beginPath();
+          ctx.fillStyle = object.ready ? "#69c36a" : "#e5a83e";
+          ctx.strokeStyle = "#fff6d8";
+          ctx.lineWidth = 1.5;
+          ctx.arc(cx, cy, object.ready ? 5 : 3.5, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.stroke();
+          if (object.ready) {
+            ctx.fillStyle = "white";
+            ctx.font = "bold 7px Arial";
+            ctx.textAlign = "center";
+            ctx.textBaseline = "middle";
+            ctx.fillText("✓", cx, cy + 0.5);
+          }
+        }
+      }
+    }
+
+    if (showSuggestions) {
+      for (const suggestion of proposalStates.filter(
+        (item) => item.status === "pending",
+      )) {
+        ctx.globalAlpha = 0.82;
+        const hasSprite = drawBuildingSprite(ctx, sprites, suggestion);
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = `${suggestion.color}80`;
+        ctx.strokeStyle = "rgba(30, 25, 18, .9)";
+        ctx.lineWidth = 5;
+        ctx.setLineDash([5, 3]);
+        ctx.fillRect(
+          suggestion.x * TILE,
+          suggestion.y * TILE,
+          suggestion.width * TILE,
+          suggestion.height * TILE,
+        );
+        ctx.strokeRect(
+          suggestion.x * TILE + 1,
+          suggestion.y * TILE + 1,
+          suggestion.width * TILE - 2,
+          suggestion.height * TILE - 2,
+        );
+        ctx.strokeStyle = suggestion.color;
+        ctx.lineWidth = 2.5;
+        ctx.strokeRect(
+          suggestion.x * TILE + 1,
+          suggestion.y * TILE + 1,
+          suggestion.width * TILE - 2,
+          suggestion.height * TILE - 2,
+        );
+        ctx.setLineDash([]);
+        if (!hasSprite || proposalEditMode) {
+          const label = suggestion.name.replace(
+            /^(Proposed|Future|Optional) /,
+            "",
+          );
+          ctx.font = "bold 9px Arial";
+          ctx.fillStyle = "rgba(28, 25, 23, .82)";
+          ctx.fillRect(
+            suggestion.x * TILE + 3,
+            suggestion.y * TILE + 3,
+            Math.min(
+              suggestion.width * TILE - 6,
+              ctx.measureText(label).width + 10,
+            ),
+            16,
+          );
+          ctx.fillStyle = "#fff8e8";
+          ctx.textAlign = "left";
+          ctx.textBaseline = "middle";
+          ctx.fillText(
+            label,
+            suggestion.x * TILE + 8,
+            suggestion.y * TILE + 11,
+            suggestion.width * TILE - 12,
+          );
+        }
+      }
+    }
+
+    if (showGrid) {
+      ctx.strokeStyle = "rgba(50, 38, 29, .24)";
+      ctx.lineWidth = 1;
+      for (let x = 0; x <= mapData.map.width; x++) {
+        ctx.beginPath();
+        ctx.moveTo(x * TILE + 0.5, 0);
+        ctx.lineTo(x * TILE + 0.5, canvas.height);
+        ctx.stroke();
+      }
+      for (let y = 0; y <= mapData.map.height; y++) {
+        ctx.beginPath();
+        ctx.moveTo(0, y * TILE + 0.5);
+        ctx.lineTo(canvas.width, y * TILE + 0.5);
+        ctx.stroke();
+      }
+    }
+
+    if (hover) {
+      const moving = movingProposalId
+        ? localSuggestions.find((item) => item.id === movingProposalId)
+        : null;
+      const selectedTool = tools.find((item) => item.id === tool) || tools[0];
+      const active = moving || selectedTool;
+      if (proposalEditMode && (moving || tool !== "inspect")) {
+        ctx.globalAlpha = 0.78;
+        drawBuildingSprite(ctx, sprites, {
+          ...active,
+          name: moving?.name || selectedTool.label,
+          x: hover.x,
+          y: hover.y,
+        });
+        ctx.globalAlpha = 1;
+      }
+      ctx.fillStyle =
+        tool === "inspect" && !moving
+          ? "rgba(255,255,255,.22)"
+          : "rgba(255, 224, 117, .35)";
+      ctx.strokeStyle = "#fff1a8";
+      ctx.lineWidth = 2;
+      ctx.fillRect(
+        hover.x * TILE,
+        hover.y * TILE,
+        active.width * TILE,
+        active.height * TILE,
+      );
+      ctx.strokeRect(
+        hover.x * TILE + 1,
+        hover.y * TILE + 1,
+        active.width * TILE - 2,
+        active.height * TILE - 2,
+      );
+    }
+  }, [
+    canvasRef,
+    base,
+    hover,
+    mapData,
+    localSuggestions,
+    movingProposalId,
+    proposalEditMode,
+    proposalStates,
+    showBlocked,
+    showGrid,
+    showProduction,
+    showState,
+    showSuggestions,
+    sprites,
+    tool,
+  ]);
+
+  useEffect(() => {
+    if (activeView === "map") draw();
+  }, [activeView, draw, mapLocation]);
+  return draw;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { useFarmCanvas } from "./dashboard/use-farm-canvas";
+
+import { useDashboardNavigation } from "./dashboard/use-dashboard-navigation";
+
 import { reconcileProposals, buildingType, buildingSignature } from "./dashboard/farm-model";
 
 import { useI18n } from "./i18n";
@@ -12,12 +16,12 @@ import { useMemo } from "react";
 import type { CSSProperties } from "react";
 import { ChangelogHistory } from "./changelog";
 import { type Snapshot, type LiveState, type Tile, type Suggestion, type Terrain, type StorageInventoryItem } from "./dashboard/snapshot-types";
-import { type FarmHistory, type ActiveView, type SessionSummary, type LiveAlertSettings, type AppNavigationTarget, type DesktopDiagnostics, type FarmOption, type UpdateState, type DesktopUpdates } from "./dashboard/ui-types";
+import { type FarmHistory, type ActiveView, type SessionSummary, type LiveAlertSettings, type DesktopDiagnostics, type FarmOption, type UpdateState, type DesktopUpdates } from "./dashboard/ui-types";
 import { defaultLiveAlertSettings, deriveLiveAlerts, LiveDataPanel, LiveAlertCenter } from "./dashboard/live-view";
 import { localizedUpdateMessage, seasonName, localizedTerrainFeature, buildingDisplayName, communityBundleName, communityRoomName, buildingPlanText, buildingCategoryName, formatGameDate, formatLiveTime, localizedInteriorName } from "./dashboard/formatting";
 import { APPLICATION_VERSION, sessionSummary, liveStorageSource, feedbackIssueUrl } from "./dashboard/selectors";
 import { localizeSnapshotGameNames } from "./dashboard/game-names";
-import { spritePaths, tileKey, TILE, sprite, cropSpriteSource, drawBuildingSprite, tools, BuildingPreview, InteriorView } from "./dashboard/farm-rendering";
+import { spritePaths, tileKey, TILE, tools, BuildingPreview, InteriorView } from "./dashboard/farm-rendering";
 import { ItemArtworkCatalogContext } from "./dashboard/artwork";
 import { LanguageModeIcon, Toggle } from "./dashboard/ui";
 import { ItemLocationDialog } from "./dashboard/storage";
@@ -28,6 +32,7 @@ import { DailyBriefView, DailyBriefModal } from "./dashboard/today-view";
 
 export default function Home() {
   const { t, text, locale, gameCatalog, mode: languageMode } = useI18n();
+  const { activeView, navigateTo, navigateHistory, navigationAvailability } = useDashboardNavigation();
   const appShellRef = useRef<HTMLElement>(null);
   const topbarRef = useRef<HTMLElement>(null);
   const [progressTabsTop, setProgressTabsTop] = useState(82);
@@ -54,21 +59,7 @@ export default function Home() {
     farmName: "Farm",
     entries: [],
   });
-  const [activeView, setActiveView] = useState<ActiveView>(() => {
-    if (typeof window === "undefined") return "map";
-    const saved =
-      window.localStorage.getItem("stardew-tool-active-view") ||
-      window.localStorage.getItem("aincrad-active-view");
-    return saved === "map" ||
-      saved === "growth" ||
-      saved === "achievements" ||
-      saved === "farm" ||
-      saved === "agenda" ||
-      saved === "fishing" ||
-      saved === "planning"
-      ? saved
-      : "map";
-  });
+
   const [showDailyBrief, setShowDailyBrief] = useState(false);
   const [showLiveAlerts, setShowLiveAlerts] = useState(false);
   const [sessionBaseline, setSessionBaseline] = useState<SessionSummary | null>(null);
@@ -84,11 +75,7 @@ export default function Home() {
       return defaultLiveAlertSettings;
     }
   });
-  const activeViewRef = useRef(activeView);
-  const navigationBackRef = useRef<AppNavigationTarget[]>([]);
-  const navigationForwardRef = useRef<AppNavigationTarget[]>([]);
-  const lastHardwareNavigationRef = useRef({ direction: "", at: 0 });
-  const [navigationAvailability, setNavigationAvailability] = useState({ back: false, forward: false });
+
   const [showLivePanel, setShowLivePanel] = useState(false);
   const livePanelCloseTimer = useRef<number | null>(null);
   const [showFarmSwitcher, setShowFarmSwitcher] = useState(false);
@@ -110,54 +97,7 @@ export default function Home() {
   const [farmOptions, setFarmOptions] = useState<FarmOption[]>([]);
   const [activeSavePath, setActiveSavePath] = useState("");
   const [switchingFarm, setSwitchingFarm] = useState("");
-  const currentNavigationTarget = useCallback((): AppNavigationTarget => {
-    const view = activeViewRef.current;
-    if (view === "farm")
-      return { view, section: window.localStorage.getItem("stardew-tool-farm-section") || "crops" };
-    if (view === "planning")
-      return { view, section: window.localStorage.getItem("stardew-tool-plan-section") || "community" };
-    return { view };
-  }, []);
-  const applyNavigationTarget = useCallback((target: AppNavigationTarget) => {
-    activeViewRef.current = target.view;
-    if (target.view === "growth" || target.view === "achievements")
-      window.localStorage.setItem("stardew-tool-progress-section", target.view);
-    if ((target.view === "farm" || target.view === "planning") && target.section) {
-      const mode = target.view === "farm" ? "farm" : "plan";
-      window.localStorage.setItem(`stardew-tool-${mode}-section`, target.section);
-      window.dispatchEvent(new CustomEvent("stardew:open-planning-section", {
-        detail: { mode, section: target.section },
-      }));
-    }
-    setActiveView(target.view);
-  }, []);
-  const navigateTo = useCallback((target: AppNavigationTarget) => {
-    const current = currentNavigationTarget();
-    if (current.view === target.view && current.section === target.section) return;
-    navigationBackRef.current.push(current);
-    navigationForwardRef.current = [];
-    applyNavigationTarget(target);
-    setNavigationAvailability({ back: true, forward: false });
-  }, [applyNavigationTarget, currentNavigationTarget]);
-  const navigateHistory = useCallback((direction: "back" | "forward") => {
-    const source = direction === "back" ? navigationBackRef : navigationForwardRef;
-    const destination = direction === "back" ? navigationForwardRef : navigationBackRef;
-    const target = source.current.pop();
-    if (!target) return;
-    destination.current.push(currentNavigationTarget());
-    applyNavigationTarget(target);
-    setNavigationAvailability({
-      back: navigationBackRef.current.length > 0,
-      forward: navigationForwardRef.current.length > 0,
-    });
-  }, [applyNavigationTarget, currentNavigationTarget]);
-  const navigateHardwareHistory = useCallback((direction: "back" | "forward") => {
-    const now = performance.now();
-    const previous = lastHardwareNavigationRef.current;
-    if (previous.direction === direction && now - previous.at < 120) return;
-    lastHardwareNavigationRef.current = { direction, at: now };
-    navigateHistory(direction);
-  }, [navigateHistory]);
+
   const [updateState, setUpdateState] = useState<UpdateState>({
     status: "idle",
   });
@@ -203,10 +143,6 @@ export default function Home() {
     if (window.innerWidth >= 2200) return 1.25;
     return 1;
   });
-
-  useEffect(() => {
-    window.localStorage.setItem("stardew-tool-active-view", activeView);
-  }, [activeView]);
 
   useEffect(() => {
     window.localStorage.setItem(
@@ -317,40 +253,6 @@ export default function Home() {
       .stardewDesktop;
     return desktop?.onOpenHelp?.(openHelp);
   }, [openHelp]);
-
-  useEffect(() => {
-    const desktop = (window as Window & { stardewDesktop?: DesktopUpdates })
-      .stardewDesktop;
-    return desktop?.onNavigateHistory?.(navigateHardwareHistory);
-  }, [navigateHardwareHistory]);
-
-  useEffect(() => {
-    const mouseHistoryShortcut = (event: MouseEvent) => {
-      if (event.button !== 3 && event.button !== 4) return;
-      event.preventDefault();
-      navigateHardwareHistory(event.button === 3 ? "back" : "forward");
-    };
-    const preventNativeHistory = (event: MouseEvent) => {
-      if (event.button === 3 || event.button === 4) event.preventDefault();
-    };
-    window.addEventListener("mousedown", mouseHistoryShortcut, true);
-    window.addEventListener("auxclick", preventNativeHistory, true);
-    return () => {
-      window.removeEventListener("mousedown", mouseHistoryShortcut, true);
-      window.removeEventListener("auxclick", preventNativeHistory, true);
-    };
-  }, [navigateHardwareHistory]);
-
-  useEffect(() => {
-    const historyShortcut = (event: KeyboardEvent) => {
-      if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
-      event.preventDefault();
-      navigateHistory(event.key === "ArrowLeft" ? "back" : "forward");
-    };
-    window.addEventListener("keydown", historyShortcut);
-    return () => window.removeEventListener("keydown", historyShortcut);
-  }, [navigateHistory]);
 
   useEffect(() => {
     const desktop = (window as Window & { stardewDesktop?: DesktopUpdates })
@@ -1073,368 +975,7 @@ export default function Home() {
     return "";
   };
 
-  const draw = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas || !mapData || !base) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    ctx.imageSmoothingEnabled = false;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(base, 0, 0);
-
-    if (mapData.farmType === 0 && (mapData.grandpa.actualCandles || 0) > 0) {
-      const candleTiles = [
-        [7.65, 8.15],
-        [8.15, 7.55],
-        [8.85, 7.55],
-        [9.35, 8.15],
-      ];
-      candleTiles
-        .slice(0, mapData.grandpa.actualCandles)
-        .forEach(([x, y]) => {
-          ctx.fillStyle = "#8b4a20";
-          ctx.fillRect(x * TILE, y * TILE, 2, 5);
-          ctx.fillStyle = "#ffd65a";
-          ctx.fillRect(x * TILE - 1, y * TILE - 4, 4, 4);
-          ctx.fillStyle = "#fff4a0";
-          ctx.fillRect(x * TILE, y * TILE - 3, 2, 2);
-        });
-    }
-
-    if (showBlocked) {
-      ctx.fillStyle = "rgba(72, 38, 76, .26)";
-      for (const [x, y] of mapData.map.blocked)
-        ctx.fillRect(x * TILE, y * TILE, TILE, TILE);
-    }
-
-    if (showState) {
-      const tall: { bottom: number; paint: () => void }[] = [];
-      for (const feature of mapData.terrain) {
-        const px = feature.x * TILE,
-          py = feature.y * TILE;
-        if (feature.kind === "HoeDirt") {
-          const soilOffset = feature.watered ? 128 : 0;
-          sprite(
-            ctx,
-            sprites.hoeDirt,
-            [soilOffset + 16, 0, 32, 32],
-            [px, py, 16, 16],
-          );
-          if (feature.crop && feature.cropRow !== undefined)
-            tall.push({
-              bottom: py + TILE,
-              paint: () => {
-                const phase = feature.dead
-                  ? 6
-                  : Math.min(feature.phase || 0, 5);
-                sprite(
-                  ctx,
-                  sprites.crops,
-                  cropSpriteSource(feature.cropRow!, phase),
-                  [px, py - 16],
-                  Boolean(feature.flip),
-                );
-              },
-            });
-        } else if (feature.kind === "Grass") {
-          const variant = Math.abs(feature.x * 17 + feature.y * 31) % 3;
-          tall.push({
-            bottom: py + TILE,
-            paint: () =>
-              sprite(
-                ctx,
-                sprites.grass,
-                [variant * 15, 0, 15, 20],
-                [px, py - 4],
-              ),
-          });
-        } else if (feature.kind === "Tree") {
-          const tree = sprites[feature.treeType || "Oak"] || sprites.Oak;
-          tall.push({
-            bottom: py + TILE,
-            paint: () => {
-              const stage = feature.stage || 0;
-              if (feature.stump && stage >= 5)
-                sprite(ctx, tree, [16, 96, 32, 32], [px - 8, py - 16]);
-              else if (stage >= 5)
-                sprite(ctx, tree, [0, 0, 48, 96], [px - 16, py - 80]);
-              else if (stage === 4)
-                sprite(ctx, tree, [0, 96, 16, 32], [px, py - 16]);
-              else if (stage === 3)
-                sprite(ctx, tree, [32, 128, 16, 16], [px, py]);
-              else {
-                const sourceX = stage === 0 ? 48 : stage === 1 ? 0 : 16;
-                sprite(ctx, tree, [sourceX, 128, 16, 16], [px, py]);
-              }
-              if (feature.fertilized && stage < 5) {
-                ctx.strokeStyle = "#ffe878";
-                ctx.strokeRect(px + 1.5, py + 1.5, 13, 13);
-              }
-            },
-          });
-        } else if (feature.kind === "FruitTree") {
-          tall.push({
-            bottom: py + TILE,
-            paint: () => {
-              const row = Math.max(
-                0,
-                Math.min(8, Number(feature.treeId || 628) - 628),
-              );
-              const slot = Math.min(feature.stage || 0, 4);
-              sprite(
-                ctx,
-                sprites.fruitTrees,
-                [slot * 48, row * 80, 48, 80],
-                [px - 16, py - 64],
-              );
-            },
-          });
-        }
-      }
-
-      for (const object of mapData.objects) {
-        const index = Number(object.id);
-        if (!Number.isFinite(index)) continue;
-        const px = object.x * TILE,
-          py = object.y * TILE;
-        tall.push({
-          bottom: py + TILE,
-          paint: () => {
-            if (object.big)
-              sprite(
-                ctx,
-                sprites.craftables,
-                [(index % 8) * 16, Math.floor(index / 8) * 32, 16, 32],
-                [px, py - 16],
-              );
-            else
-              sprite(
-                ctx,
-                sprites.objects,
-                [(index % 24) * 16, Math.floor(index / 24) * 16, 16, 16],
-                [px, py],
-              );
-          },
-        });
-      }
-
-      for (const clump of mapData.clumps) {
-        tall.push({
-          bottom: (clump.y + clump.height) * TILE,
-          paint: () => {
-            const index = Number(clump.id);
-            for (let y = 0; y < clump.height; y++)
-              for (let x = 0; x < clump.width; x++) {
-                const part = index + y * 24 + x;
-                sprite(
-                  ctx,
-                  sprites.objects,
-                  [(part % 24) * 16, Math.floor(part / 24) * 16, 16, 16],
-                  [(clump.x + x) * TILE, (clump.y + y) * TILE],
-                );
-              }
-          },
-        });
-      }
-
-      for (const building of mapData.buildings) {
-        tall.push({
-          bottom: (building.y + building.height) * TILE,
-          paint: () => {
-            const px = building.x * TILE,
-              py = building.y * TILE;
-            if (!drawBuildingSprite(ctx, sprites, building)) {
-              ctx.fillStyle = "rgba(116,82,154,.35)";
-              ctx.fillRect(
-                px,
-                py,
-                building.width * TILE,
-                building.height * TILE,
-              );
-            }
-            if ((building.daysOfConstructionLeft || 0) > 0) {
-              ctx.fillStyle = "rgba(240, 167, 55, .2)";
-              ctx.strokeStyle = "#ffd166";
-              ctx.lineWidth = 2;
-              ctx.setLineDash([5, 3]);
-              ctx.fillRect(
-                px,
-                py,
-                building.width * TILE,
-                building.height * TILE,
-              );
-              ctx.strokeRect(
-                px + 1,
-                py + 1,
-                building.width * TILE - 2,
-                building.height * TILE - 2,
-              );
-              ctx.setLineDash([]);
-            }
-          },
-        });
-      }
-      tall
-        .sort((a, b) => a.bottom - b.bottom)
-        .forEach((entity) => entity.paint());
-
-      if (showProduction) {
-        for (const object of mapData.objects.filter(
-          (item) => item.ready || item.processing,
-        )) {
-          const cx = object.x * TILE + 12,
-            cy = object.y * TILE + 3;
-          ctx.beginPath();
-          ctx.fillStyle = object.ready ? "#69c36a" : "#e5a83e";
-          ctx.strokeStyle = "#fff6d8";
-          ctx.lineWidth = 1.5;
-          ctx.arc(cx, cy, object.ready ? 5 : 3.5, 0, Math.PI * 2);
-          ctx.fill();
-          ctx.stroke();
-          if (object.ready) {
-            ctx.fillStyle = "white";
-            ctx.font = "bold 7px Arial";
-            ctx.textAlign = "center";
-            ctx.textBaseline = "middle";
-            ctx.fillText("✓", cx, cy + 0.5);
-          }
-        }
-      }
-    }
-
-    if (showSuggestions) {
-      for (const suggestion of proposalStates.filter(
-        (item) => item.status === "pending",
-      )) {
-        ctx.globalAlpha = 0.82;
-        const hasSprite = drawBuildingSprite(ctx, sprites, suggestion);
-        ctx.globalAlpha = 1;
-        ctx.fillStyle = `${suggestion.color}80`;
-        ctx.strokeStyle = "rgba(30, 25, 18, .9)";
-        ctx.lineWidth = 5;
-        ctx.setLineDash([5, 3]);
-        ctx.fillRect(
-          suggestion.x * TILE,
-          suggestion.y * TILE,
-          suggestion.width * TILE,
-          suggestion.height * TILE,
-        );
-        ctx.strokeRect(
-          suggestion.x * TILE + 1,
-          suggestion.y * TILE + 1,
-          suggestion.width * TILE - 2,
-          suggestion.height * TILE - 2,
-        );
-        ctx.strokeStyle = suggestion.color;
-        ctx.lineWidth = 2.5;
-        ctx.strokeRect(
-          suggestion.x * TILE + 1,
-          suggestion.y * TILE + 1,
-          suggestion.width * TILE - 2,
-          suggestion.height * TILE - 2,
-        );
-        ctx.setLineDash([]);
-        if (!hasSprite || proposalEditMode) {
-          const label = suggestion.name.replace(
-            /^(Proposed|Future|Optional) /,
-            "",
-          );
-          ctx.font = "bold 9px Arial";
-          ctx.fillStyle = "rgba(28, 25, 23, .82)";
-          ctx.fillRect(
-            suggestion.x * TILE + 3,
-            suggestion.y * TILE + 3,
-            Math.min(
-              suggestion.width * TILE - 6,
-              ctx.measureText(label).width + 10,
-            ),
-            16,
-          );
-          ctx.fillStyle = "#fff8e8";
-          ctx.textAlign = "left";
-          ctx.textBaseline = "middle";
-          ctx.fillText(
-            label,
-            suggestion.x * TILE + 8,
-            suggestion.y * TILE + 11,
-            suggestion.width * TILE - 12,
-          );
-        }
-      }
-    }
-
-    if (showGrid) {
-      ctx.strokeStyle = "rgba(50, 38, 29, .24)";
-      ctx.lineWidth = 1;
-      for (let x = 0; x <= mapData.map.width; x++) {
-        ctx.beginPath();
-        ctx.moveTo(x * TILE + 0.5, 0);
-        ctx.lineTo(x * TILE + 0.5, canvas.height);
-        ctx.stroke();
-      }
-      for (let y = 0; y <= mapData.map.height; y++) {
-        ctx.beginPath();
-        ctx.moveTo(0, y * TILE + 0.5);
-        ctx.lineTo(canvas.width, y * TILE + 0.5);
-        ctx.stroke();
-      }
-    }
-
-    if (hover) {
-      const moving = movingProposalId
-        ? localSuggestions.find((item) => item.id === movingProposalId)
-        : null;
-      const selectedTool = tools.find((item) => item.id === tool) || tools[0];
-      const active = moving || selectedTool;
-      if (proposalEditMode && (moving || tool !== "inspect")) {
-        ctx.globalAlpha = 0.78;
-        drawBuildingSprite(ctx, sprites, {
-          ...active,
-          name: moving?.name || selectedTool.label,
-          x: hover.x,
-          y: hover.y,
-        });
-        ctx.globalAlpha = 1;
-      }
-      ctx.fillStyle =
-        tool === "inspect" && !moving
-          ? "rgba(255,255,255,.22)"
-          : "rgba(255, 224, 117, .35)";
-      ctx.strokeStyle = "#fff1a8";
-      ctx.lineWidth = 2;
-      ctx.fillRect(
-        hover.x * TILE,
-        hover.y * TILE,
-        active.width * TILE,
-        active.height * TILE,
-      );
-      ctx.strokeRect(
-        hover.x * TILE + 1,
-        hover.y * TILE + 1,
-        active.width * TILE - 2,
-        active.height * TILE - 2,
-      );
-    }
-  }, [
-    base,
-    hover,
-    mapData,
-    localSuggestions,
-    movingProposalId,
-    proposalEditMode,
-    proposalStates,
-    showBlocked,
-    showGrid,
-    showProduction,
-    showState,
-    showSuggestions,
-    sprites,
-    tool,
-  ]);
-
-  useEffect(() => {
-    if (activeView === "map") draw();
-  }, [activeView, draw, mapLocation]);
+  const draw = useFarmCanvas({ canvasRef, base, hover, mapData, localSuggestions, movingProposalId, proposalEditMode, proposalStates, showBlocked, showGrid, showProduction, showState, showSuggestions, sprites, tool, activeView, mapLocation });
 
   const pointFromEvent = (event: React.MouseEvent<HTMLCanvasElement>) => {
     const rect = event.currentTarget.getBoundingClientRect();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node scripts/dev-local.mjs",
     "build": "npm run verify:changelog && vinext build && node scripts/prepare-built-public.mjs",
     "start": "vinext start",
-    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs tests/fishing-snapshot.test.mjs tests/mod-consumers.test.mjs tests/mod-production-extractor.test.mjs tests/dashboard-modules.test.mjs",
+    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs tests/fishing-snapshot.test.mjs tests/mod-consumers.test.mjs tests/mod-production-extractor.test.mjs tests/dashboard-modules.test.mjs tests/dashboard-navigation.test.mjs",
     "verify:changelog": "node scripts/verify-changelog.mjs",
     "verify:localization": "node scripts/verify-localization-ui.mjs",
     "verify:public": "node scripts/verify-public-safety.mjs",

--- a/tests/dashboard-navigation.test.mjs
+++ b/tests/dashboard-navigation.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+test("navigation preserves section history, shortcuts and listener cleanup", async () => {
+  const originalWindow = globalThis.window;
+  const storage = new Map([["stardew-tool-active-view", "map"]]);
+  const events = new EventTarget();
+  const states = [];
+  const effects = [];
+  let stateIndex = 0;
+  globalThis.window = Object.assign(events, {
+    localStorage: { getItem: (key) => storage.get(key) ?? null, setItem: (key, value) => storage.set(key, value) },
+  });
+  globalThis.__navigationTestHooks = {
+    useRef: (current) => ({ current }),
+    useState: (initial) => {
+      const index = stateIndex++;
+      states[index] = typeof initial === "function" ? initial() : initial;
+      return [states[index], (value) => { states[index] = value; }];
+    },
+    useCallback: (callback) => callback,
+    useEffect: (effect) => effects.push(effect),
+  };
+  let cleanup = [];
+  try {
+    const source = await readFile(new URL("../app/dashboard/use-dashboard-navigation.ts", import.meta.url), "utf8");
+    const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 } });
+    const code = outputText.replace(/import\s*\{([^}]+)\}\s*from "react";/, "const {$1} = globalThis.__navigationTestHooks;");
+    const { useDashboardNavigation } = await import(`data:text/javascript;base64,${Buffer.from(code).toString("base64")}`);
+    const navigation = useDashboardNavigation();
+    cleanup = effects.map((effect) => effect()).filter(Boolean);
+    assert.equal(navigation.activeView, "map");
+    navigation.navigateTo({ view: "planning", section: "community" });
+    navigation.navigateTo({ view: "fishing" });
+    navigation.navigateHistory("back");
+    assert.equal(states[0], "planning");
+    assert.equal(storage.get("stardew-tool-plan-section"), "community");
+    assert.deepEqual(states[1], { back: true, forward: true });
+    navigation.navigateHistory("forward");
+    assert.equal(states[0], "fishing");
+    navigation.navigateTo({ view: "growth" });
+    assert.deepEqual(states[1], { back: true, forward: false });
+    assert.equal(storage.get("stardew-tool-progress-section"), "growth");
+    const shortcut = () => Object.assign(new Event("keydown", { cancelable: true }), { altKey: true, key: "ArrowLeft" });
+    events.dispatchEvent(shortcut());
+    assert.equal(states[0], "fishing");
+    cleanup.forEach((dispose) => dispose());
+    cleanup = [];
+    events.dispatchEvent(shortcut());
+    assert.equal(states[0], "fishing", "unmounted navigation must remove its keyboard listener");
+  } finally {
+    cleanup.forEach((dispose) => dispose());
+    globalThis.window = originalWindow;
+    delete globalThis.__navigationTestHooks;
+  }
+});


### PR DESCRIPTION
## Changes
Extract section history and desktop, mouse and keyboard navigation subscriptions into useDashboardNavigation. Extract the existing farm drawing callback and redraw effect into useFarmCanvas, preserving the callback used when reopening the map. The page retains state orchestration and editor interactions.

Second incremental delivery for #16. No planned changes to visual behavior, game data or persistence keys. Outer editor and legacy name-based rule cleanup remain tracked in #16.

## Validation
- Public safety, ESLint, TypeScript and build passed.
- npm test: 146 passed, one opt-in local integration test skipped.
- New behavioral navigation test covers section restoration, back/forward history, forward-history invalidation, keyboard shortcuts and listener cleanup.
- Existing graph and rendering checks pass.

## Manual checks
Navigate between map, fishing and a planning subsection; use Back/Forward and Alt+Left/Right. Return to the farm map, toggle layers, zoom and inspect construction proposals. Behavior should remain unchanged.

Awaiting maintainer approval for squash merge and branch deletion.
