### PR TITLE
feat(map): expose proposal actions and isolate editor state

### DIFF
--- a/app/dashboard/README.md
+++ b/app/dashboard/README.md
@@ -5,7 +5,7 @@
 - `snapshot-types.ts` defines saved/local data contracts. `ui-types.ts` holds view state and presentation contracts. Production catalog contracts live in `app/planning/production-types.ts`, independently of the calculator component.
 - `identity.ts`, `game-names.ts`, `formatting.ts` and `selectors.ts` provide shared identity, localization, formatting and reconciliation helpers. `farm-model.ts` reconciles construction proposals without React or canvas.
 - `fishing-view.tsx`, `planning-view.tsx`, `today-view.tsx`, `progress-view.tsx` and `live-view.tsx` own their respective views.
-- `use-dashboard-navigation.ts` owns section history and desktop/mouse/keyboard navigation subscriptions. `use-farm-canvas.ts` owns farm drawing and redraw dependencies. `farm-rendering.tsx` owns canvas helpers and interior rendering. `artwork.tsx`, `storage.tsx` and `ui.tsx` own reusable artwork, storage dialogs and controls.
+- `use-farm-editor.ts` owns map preferences, selection, proposals, movement and editor handlers; `farm-model.ts` validates placement without React. `use-dashboard-navigation.ts` owns section history and desktop/mouse/keyboard navigation subscriptions. `use-farm-canvas.ts` owns farm drawing and redraw dependencies. `farm-rendering.tsx` owns canvas helpers and interior rendering. `artwork.tsx`, `storage.tsx` and `ui.tsx` own reusable artwork, storage dialogs and controls.
 
 Imports flow from the page to features and from features to shared modules. Shared modules must not import feature views or the page. A test checks the module graph, including type dependencies, for cycles.
 

--- a/app/dashboard/farm-model.ts
+++ b/app/dashboard/farm-model.ts
@@ -1,5 +1,5 @@
-import type { Building, Suggestion } from "./snapshot-types";
-import type { ProposalState } from "./ui-types";
+import type { Building, Suggestion, Snapshot, Tile } from "./snapshot-types";
+import type { ProposalState, Translate } from "./ui-types";
 
 export function buildingType(item: Pick<Building, "name"> & { kind?: string }) {
   const value = `${item.kind || ""} ${item.name}`.toLowerCase();
@@ -81,3 +81,71 @@ export function reconcileProposals(
       };
     });
 }
+
+export function validateFarmPlacement(mapData: Snapshot | null, proposalStates: ProposalState[], point: Tile, width: number, height: number, t: Translate) {
+    if (!mapData) return t("map.error.unavailable");
+    const cells = Array.from({ length: width * height }, (_, index) => ({
+      x: point.x + (index % width),
+      y: point.y + Math.floor(index / width),
+    }));
+    if (
+      cells.some(
+        (cell) =>
+          cell.x < 0 ||
+          cell.y < 0 ||
+          cell.x >= mapData.map.width ||
+          cell.y >= mapData.map.height,
+      )
+    )
+      return t("map.error.outsideFarm");
+    if (
+      cells.some((cell) =>
+        mapData.map.blocked.some(([x, y]) => x === cell.x && y === cell.y),
+      )
+    )
+      return t("map.error.nonBuildable");
+    if (
+      cells.some((cell) =>
+        mapData.buildings.some(
+          (building) =>
+            cell.x >= building.x &&
+            cell.x < building.x + building.width &&
+            cell.y >= building.y &&
+            cell.y < building.y + building.height,
+        ),
+      )
+    )
+      return t("map.error.existingBuilding");
+    if (
+      cells.some((cell) =>
+        mapData.objects.some(
+          (object) => {
+            if (object.x !== cell.x || object.y !== cell.y) return false;
+            if (object.kind === "Litter" || object.name === "Artifact Spot")
+              return false;
+            return !mapData.terrain.some(
+              (feature) =>
+                feature.x === object.x &&
+                feature.y === object.y &&
+                ["Tree", "FruitTree"].includes(feature.kind),
+            );
+          },
+        ),
+      )
+    )
+      return t("map.error.placedObject");
+    if (
+      cells.some((cell) =>
+        proposalStates.some(
+          (proposal) =>
+            proposal.status === "pending" &&
+            cell.x >= proposal.x &&
+            cell.x < proposal.x + proposal.width &&
+            cell.y >= proposal.y &&
+            cell.y < proposal.y + proposal.height,
+        ),
+      )
+    )
+      return t("map.error.pendingProposal");
+    return "";
+  }

--- a/app/dashboard/use-farm-editor.ts
+++ b/app/dashboard/use-farm-editor.ts
@@ -285,6 +285,10 @@ export function useFarmEditor(data: Snapshot | null, live: LiveState, activeView
       setPlacementError("");
       return;
     }
+    if (!proposalEditMode || tool === "inspect") {
+      openProposalMenu(event);
+      return;
+    }
     if (proposalEditMode && tool !== "inspect") {
       const active = tools.find((item) => item.id === tool)!;
       const invalid = validatePlacement(point, active.width, active.height);
@@ -312,6 +316,7 @@ export function useFarmEditor(data: Snapshot | null, live: LiveState, activeView
 
   const openProposalMenu = (event: React.MouseEvent<HTMLCanvasElement>) => {
     event.preventDefault();
+    event.stopPropagation();
     const point = pointFromEvent(event);
     const proposal = [...localSuggestions].reverse().find(
       (item) =>

--- a/app/dashboard/use-farm-editor.ts
+++ b/app/dashboard/use-farm-editor.ts
@@ -1,0 +1,343 @@
+"use client";
+
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { useI18n } from "../i18n";
+import type { Snapshot, LiveState, Tile, Suggestion, Terrain } from "./snapshot-types";
+import type { ActiveView } from "./ui-types";
+import { reconcileProposals, buildingType, validateFarmPlacement } from "./farm-model";
+import { tileKey, TILE, tools } from "./farm-rendering";
+
+export function useFarmEditor(data: Snapshot | null, live: LiveState, activeView: ActiveView) {
+  const { t } = useI18n();
+  const [initialMapPreferences] = useState<Record<string, unknown>>(() => {
+    if (typeof window === "undefined") return {};
+    try {
+      return JSON.parse(
+        window.localStorage.getItem("stardew-tool-map-preferences") ||
+          window.localStorage.getItem("aincrad-map-preferences") ||
+          "{}",
+      );
+    } catch {
+      return {};
+    }
+  });
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const mapViewportRef = useRef<HTMLDivElement>(null);
+
+  const hasCenteredFarmRef = useRef(false);
+
+  const [zoom, setZoom] = useState(() =>
+    typeof initialMapPreferences.zoom === "number"
+      ? Math.max(0.65, Math.min(2.1, initialMapPreferences.zoom))
+      : 1,
+  );
+
+  const [hover, setHover] = useState<Tile | null>(null);
+
+  const [selected, setSelected] = useState<Tile | null>(null);
+
+  const [tool, setTool] = useState("inspect");
+
+  const [proposalEditMode, setProposalEditMode] = useState(false);
+
+  const [movingProposalId, setMovingProposalId] = useState<string | null>(null);
+
+  const [proposalMenu, setProposalMenu] = useState<{
+    id: string;
+    name: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const [proposalUndo, setProposalUndo] = useState<Suggestion[] | null>(null);
+
+  const [showGrid, setShowGrid] = useState(() =>
+    typeof initialMapPreferences.showGrid === "boolean"
+      ? initialMapPreferences.showGrid
+      : false,
+  );
+
+  const [showState, setShowState] = useState(() =>
+    typeof initialMapPreferences.showState === "boolean"
+      ? initialMapPreferences.showState
+      : true,
+  );
+
+  const [showProduction, setShowProduction] = useState(() =>
+    typeof initialMapPreferences.showProduction === "boolean"
+      ? initialMapPreferences.showProduction
+      : true,
+  );
+
+  const [showBlocked, setShowBlocked] = useState(() =>
+    typeof initialMapPreferences.showBlocked === "boolean"
+      ? initialMapPreferences.showBlocked
+      : false,
+  );
+
+  const [showSuggestions, setShowSuggestions] = useState(() =>
+    typeof initialMapPreferences.showSuggestions === "boolean"
+      ? initialMapPreferences.showSuggestions
+      : true,
+  );
+
+  const [localSuggestions, setLocalSuggestions] = useState<Suggestion[]>([]);
+
+  const [proposalLinks, setProposalLinks] = useState<Record<string, string>>({});
+
+  const [proposalResolutions, setProposalResolutions] = useState<
+    Record<string, "resolved">
+  >({});
+
+  const [placementError, setPlacementError] = useState("");
+
+  const [mapLocation, setMapLocation] = useState(() =>
+    typeof initialMapPreferences.location === "string"
+      ? initialMapPreferences.location
+      : "farm",
+  );
+
+  useEffect(() => {
+    fetch("/api/preferences", { cache: "no-store" })
+      .then((response) => response.json())
+      .then((preferences) => {
+        if (Array.isArray(preferences.suggestions))
+          setLocalSuggestions(preferences.suggestions);
+        if (
+          preferences.proposalLinks &&
+          typeof preferences.proposalLinks === "object" &&
+          !Array.isArray(preferences.proposalLinks)
+        )
+          setProposalLinks(preferences.proposalLinks);
+        if (
+          preferences.proposalResolutions &&
+          typeof preferences.proposalResolutions === "object" &&
+          !Array.isArray(preferences.proposalResolutions)
+        )
+          setProposalResolutions(preferences.proposalResolutions);
+      })
+      .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      "stardew-tool-map-preferences",
+      JSON.stringify({
+        zoom,
+        location: mapLocation,
+        showGrid,
+        showState,
+        showProduction,
+        showBlocked,
+        showSuggestions,
+      }),
+    );
+  }, [
+    mapLocation,
+    showBlocked,
+    showGrid,
+    showProduction,
+    showState,
+    showSuggestions,
+    zoom,
+  ]);
+
+  useEffect(() => {
+    if (!data || mapLocation === "farm") return;
+    if (!data.interiors.some((interior) => interior.id === mapLocation)) {
+      const frame = window.requestAnimationFrame(() => setMapLocation("farm"));
+      return () => window.cancelAnimationFrame(frame);
+    }
+  }, [data, mapLocation]);
+
+  const persist = (next: Suggestion[], remember = true) => {
+    if (remember) setProposalUndo(localSuggestions);
+    setLocalSuggestions(next);
+    fetch("/api/preferences", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ suggestions: next }),
+    }).catch(() => undefined);
+  };
+
+  const persistProposalLinks = (next: Record<string, string>) => {
+    setProposalLinks(next);
+    fetch("/api/preferences", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ proposalLinks: next }),
+    }).catch(() => undefined);
+  };
+
+  const persistProposalResolutions = (next: Record<string, "resolved">) => {
+    setProposalResolutions(next);
+    fetch("/api/preferences", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ proposalResolutions: next }),
+    }).catch(() => undefined);
+  };
+
+  const mapData = useMemo(() => {
+    if (!data || !live.active || !live.farmMap) return data;
+    const savedTerrain = new Map(
+      data.terrain.map((feature) => [tileKey(feature.x, feature.y), feature]),
+    );
+    const terrain = live.farmMap.terrain.map((feature) => {
+      const saved = savedTerrain.get(tileKey(feature.x, feature.y));
+      if (!saved)
+        return {
+          x: feature.x,
+          y: feature.y,
+          kind: feature.kind,
+          watered: feature.watered,
+        } as Terrain;
+      if (feature.kind === "HoeDirt" && !feature.hasCrop) {
+        const soil = { ...saved };
+        delete soil.crop;
+        delete soil.phase;
+        delete soil.cropRow;
+        return { ...soil, watered: feature.watered };
+      }
+      return { ...saved, watered: feature.watered };
+    });
+    return {
+      ...data,
+      terrain,
+      objects: live.farmMap.objects,
+      buildings: live.farmMap.buildings,
+    };
+  }, [data, live.active, live.farmMap]);
+
+  const proposalStates = useMemo(
+    () =>
+      mapData
+        ? reconcileProposals(
+            [...mapData.suggestions, ...localSuggestions],
+            mapData.buildings,
+            proposalLinks,
+            proposalResolutions,
+          )
+        : [],
+    [localSuggestions, mapData, proposalLinks, proposalResolutions],
+  );
+
+  const centerOnFarmhouse = useCallback(
+    (behavior: ScrollBehavior = "auto") => {
+      const viewport = mapViewportRef.current;
+      const farmhouse = mapData?.buildings.find(
+        (building) => buildingType(building) === "farmhouse",
+      );
+      if (!viewport || !farmhouse) return;
+      const centerX = (farmhouse.x + farmhouse.width / 2) * TILE * zoom;
+      const centerY = (farmhouse.y + farmhouse.height / 2) * TILE * zoom;
+      viewport.scrollTo({
+        left: Math.max(0, centerX - viewport.clientWidth / 2),
+        top: Math.max(0, centerY - viewport.clientHeight / 2),
+        behavior,
+      });
+    },
+    [mapData, zoom],
+  );
+
+  useEffect(() => {
+    if (activeView !== "map" || mapLocation !== "farm") return;
+    if (hasCenteredFarmRef.current) return;
+    if (
+      !mapData ||
+      !mapViewportRef.current ||
+      !mapData.buildings.some(
+        (building) => buildingType(building) === "farmhouse",
+      )
+    )
+      return;
+    hasCenteredFarmRef.current = true;
+    const frame = window.requestAnimationFrame(() => centerOnFarmhouse("auto"));
+    return () => window.cancelAnimationFrame(frame);
+  }, [activeView, centerOnFarmhouse, mapData, mapLocation]);
+
+  const validatePlacement = (point: Tile, width: number, height: number) =>
+    validateFarmPlacement(mapData, proposalStates, point, width, height, t);
+
+  const pointFromEvent = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return {
+      x: Math.floor(((event.clientX - rect.left) / rect.width) * 80),
+      y: Math.floor(((event.clientY - rect.top) / rect.height) * 65),
+    };
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    setProposalMenu(null);
+    const point = pointFromEvent(event);
+    setSelected(point);
+    if (movingProposalId) {
+      const moving = localSuggestions.find((item) => item.id === movingProposalId);
+      if (!moving) return setMovingProposalId(null);
+      const invalid = validatePlacement(point, moving.width, moving.height);
+      if (invalid) return setPlacementError(invalid);
+      persist(localSuggestions.map((item) =>
+        item.id === movingProposalId ? { ...item, x: point.x, y: point.y } : item,
+      ));
+      setMovingProposalId(null);
+      setPlacementError("");
+      return;
+    }
+    if (proposalEditMode && tool !== "inspect") {
+      const active = tools.find((item) => item.id === tool)!;
+      const invalid = validatePlacement(point, active.width, active.height);
+      if (invalid) {
+        setPlacementError(invalid);
+        return;
+      }
+      setPlacementError("");
+      persist([
+        ...localSuggestions,
+        {
+          id: `${tool}-${Date.now()}`,
+          kind: tool,
+          name: `Proposed ${active.label}`,
+          x: point.x,
+          y: point.y,
+          width: active.width,
+          height: active.height,
+          color: "#ffcf5c",
+        },
+      ]);
+      setTool("inspect");
+    }
+  };
+
+  const openProposalMenu = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    event.preventDefault();
+    const point = pointFromEvent(event);
+    const proposal = [...localSuggestions].reverse().find(
+      (item) =>
+        point.x >= item.x &&
+        point.x < item.x + item.width &&
+        point.y >= item.y &&
+        point.y < item.y + item.height,
+    );
+    if (!proposal) {
+      setProposalMenu(null);
+      return;
+    }
+    setProposalMenu({
+      id: proposal.id,
+      name: proposal.name.replace(/^(Proposed|Future|Optional) /, ""),
+      x: event.clientX,
+      y: event.clientY,
+    });
+  };
+
+  useEffect(() => {
+    if (!proposalMenu) return;
+    const close = () => setProposalMenu(null);
+    document.addEventListener("click", close);
+    return () => document.removeEventListener("click", close);
+  }, [proposalMenu]);
+
+  return { hover, movingProposalId, mapData, selected, mapLocation, showState, setShowState, showProduction, setShowProduction, proposalStates, showSuggestions, setShowSuggestions, showGrid, setShowGrid, showBlocked, setShowBlocked, proposalEditMode, setProposalEditMode, setTool, setMovingProposalId, tool, proposalUndo, setProposalUndo, localSuggestions, persist, setMapLocation, setSelected, setPlacementError, centerOnFarmhouse, setZoom, zoom, mapViewportRef, canvasRef, setHover, pointFromEvent, handleClick, openProposalMenu, proposalMenu, setProposalMenu, placementError, persistProposalResolutions, proposalResolutions, persistProposalLinks, proposalLinks };
+}

--- a/app/dashboard/use-farm-editor.ts
+++ b/app/dashboard/use-farm-editor.ts
@@ -269,7 +269,31 @@ export function useFarmEditor(data: Snapshot | null, live: LiveState, activeView
     };
   };
 
-  const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+  const openProposalMenu = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const point = pointFromEvent(event);
+    const proposal = [...localSuggestions].reverse().find(
+      (item) =>
+        point.x >= item.x &&
+        point.x < item.x + item.width &&
+        point.y >= item.y &&
+        point.y < item.y + item.height,
+    );
+    if (!proposal) {
+      setProposalMenu(null);
+      return;
+    }
+    setProposalMenu({
+      id: proposal.id,
+      name: proposal.name.replace(/^(Proposed|Future|Optional) /, ""),
+      x: event.clientX,
+      y: event.clientY,
+    });
+  };
+
+
+  const handleClick = useCallback((event: React.MouseEvent<HTMLCanvasElement>) => {
     setProposalMenu(null);
     const point = pointFromEvent(event);
     setSelected(point);
@@ -312,30 +336,8 @@ export function useFarmEditor(data: Snapshot | null, live: LiveState, activeView
       ]);
       setTool("inspect");
     }
-  };
+  }, [localSuggestions, movingProposalId, openProposalMenu, persist, proposalEditMode, tool, validatePlacement]);
 
-  const openProposalMenu = (event: React.MouseEvent<HTMLCanvasElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const point = pointFromEvent(event);
-    const proposal = [...localSuggestions].reverse().find(
-      (item) =>
-        point.x >= item.x &&
-        point.x < item.x + item.width &&
-        point.y >= item.y &&
-        point.y < item.y + item.height,
-    );
-    if (!proposal) {
-      setProposalMenu(null);
-      return;
-    }
-    setProposalMenu({
-      id: proposal.id,
-      name: proposal.name.replace(/^(Proposed|Future|Optional) /, ""),
-      x: event.clientX,
-      y: event.clientY,
-    });
-  };
 
   useEffect(() => {
     if (!proposalMenu) return;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1715,8 +1715,44 @@ export default function Home() {
                 }}
               >
                 <strong>{proposalMenu.name}</strong>
+                {proposalStates.find((proposal) => proposal.id === proposalMenu.id)?.status === "pending" && (
+                  <>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setProposalEditMode(true);
+                        setMovingProposalId(proposalMenu.id);
+                        setTool("inspect");
+                        setPlacementError(t("map.proposal.chooseNewPosition"));
+                        setProposalMenu(null);
+                      }}
+                    >{t("web.home.move")}</button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        persistProposalResolutions({ ...proposalResolutions, [proposalMenu.id]: "resolved" });
+                        setProposalMenu(null);
+                      }}
+                    >{t("web.home.markPlanDone")}</button>
+                  </>
+                )}
+                {proposalStates.find((proposal) => proposal.id === proposalMenu.id)?.status === "resolved" && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      const next = { ...proposalResolutions };
+                      delete next[proposalMenu.id];
+                      persistProposalResolutions(next);
+                      setProposalMenu(null);
+                    }}
+                  >{t("web.home.reopenPlan")}</button>
+                )}
                 <button
                   type="button"
+                  role="menuitem"
                   onClick={() => {
                     persist(localSuggestions.filter((item) => item.id !== proposalMenu.id));
                     setProposalMenu(null);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useFarmEditor } from "./dashboard/use-farm-editor";
+
 import { useFarmCanvas } from "./dashboard/use-farm-canvas";
 
 import { useDashboardNavigation } from "./dashboard/use-dashboard-navigation";
 
-import { reconcileProposals, buildingType, buildingSignature } from "./dashboard/farm-model";
+import { buildingType, buildingSignature } from "./dashboard/farm-model";
 
 import { useI18n } from "./i18n";
 import { useRef } from "react";
@@ -12,16 +14,15 @@ import { useState } from "react";
 import { useCallback } from "react";
 import { useEffect } from "react";
 import type { AppLanguageMode } from "./i18n";
-import { useMemo } from "react";
 import type { CSSProperties } from "react";
 import { ChangelogHistory } from "./changelog";
-import { type Snapshot, type LiveState, type Tile, type Suggestion, type Terrain, type StorageInventoryItem } from "./dashboard/snapshot-types";
+import { type Snapshot, type LiveState, type StorageInventoryItem } from "./dashboard/snapshot-types";
 import { type FarmHistory, type ActiveView, type SessionSummary, type LiveAlertSettings, type DesktopDiagnostics, type FarmOption, type UpdateState, type DesktopUpdates } from "./dashboard/ui-types";
 import { defaultLiveAlertSettings, deriveLiveAlerts, LiveDataPanel, LiveAlertCenter } from "./dashboard/live-view";
 import { localizedUpdateMessage, seasonName, localizedTerrainFeature, buildingDisplayName, communityBundleName, communityRoomName, buildingPlanText, buildingCategoryName, formatGameDate, formatLiveTime, localizedInteriorName } from "./dashboard/formatting";
 import { APPLICATION_VERSION, sessionSummary, liveStorageSource, feedbackIssueUrl } from "./dashboard/selectors";
 import { localizeSnapshotGameNames } from "./dashboard/game-names";
-import { spritePaths, tileKey, TILE, tools, BuildingPreview, InteriorView } from "./dashboard/farm-rendering";
+import { spritePaths, tileKey, tools, BuildingPreview, InteriorView } from "./dashboard/farm-rendering";
 import { ItemArtworkCatalogContext } from "./dashboard/artwork";
 import { LanguageModeIcon, Toggle } from "./dashboard/ui";
 import { ItemLocationDialog } from "./dashboard/storage";
@@ -36,22 +37,11 @@ export default function Home() {
   const appShellRef = useRef<HTMLElement>(null);
   const topbarRef = useRef<HTMLElement>(null);
   const [progressTabsTop, setProgressTabsTop] = useState(82);
-  const [initialMapPreferences] = useState<Record<string, unknown>>(() => {
-    if (typeof window === "undefined") return {};
-    try {
-      return JSON.parse(
-        window.localStorage.getItem("stardew-tool-map-preferences") ||
-          window.localStorage.getItem("aincrad-map-preferences") ||
-          "{}",
-      );
-    } catch {
-      return {};
-    }
-  });
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+
   const workspaceRef = useRef<HTMLElement>(null);
-  const mapViewportRef = useRef<HTMLDivElement>(null);
-  const hasCenteredFarmRef = useRef(false);
+
+
   const [data, setData] = useState<Snapshot | null>(null);
   const [previousDay, setPreviousDay] = useState<Snapshot | null>(null);
   const [history, setHistory] = useState<FarmHistory>({
@@ -500,85 +490,31 @@ export default function Home() {
   }, [rightPanelWidth]);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
   const [live, setLive] = useState<LiveState>({ active: false });
+  const { mapData, selected, mapLocation, showState, setShowState, showProduction, setShowProduction, proposalStates, showSuggestions, setShowSuggestions, showGrid, setShowGrid, showBlocked, setShowBlocked, proposalEditMode, setProposalEditMode, setTool, setMovingProposalId, tool, proposalUndo, setProposalUndo, localSuggestions, persist, setMapLocation, setSelected, setPlacementError, centerOnFarmhouse, setZoom, zoom, mapViewportRef, canvasRef, setHover, pointFromEvent, handleClick, openProposalMenu, proposalMenu, setProposalMenu, placementError, persistProposalResolutions, proposalResolutions, persistProposalLinks, proposalLinks , hover, movingProposalId } = useFarmEditor(data, live, activeView);
   const [base, setBase] = useState<HTMLImageElement | null>(null);
   const [sprites, setSprites] = useState<Record<string, HTMLImageElement>>({});
   const [assetError, setAssetError] = useState("");
   const [dataLoadError, setDataLoadError] = useState("");
-  const [zoom, setZoom] = useState(() =>
-    typeof initialMapPreferences.zoom === "number"
-      ? Math.max(0.65, Math.min(2.1, initialMapPreferences.zoom))
-      : 1,
-  );
-  const [hover, setHover] = useState<Tile | null>(null);
-  const [selected, setSelected] = useState<Tile | null>(null);
-  const [tool, setTool] = useState("inspect");
-  const [proposalEditMode, setProposalEditMode] = useState(false);
-  const [movingProposalId, setMovingProposalId] = useState<string | null>(null);
-  const [proposalMenu, setProposalMenu] = useState<{
-    id: string;
-    name: string;
-    x: number;
-    y: number;
-  } | null>(null);
-  const [proposalUndo, setProposalUndo] = useState<Suggestion[] | null>(null);
-  const [showGrid, setShowGrid] = useState(() =>
-    typeof initialMapPreferences.showGrid === "boolean"
-      ? initialMapPreferences.showGrid
-      : false,
-  );
-  const [showState, setShowState] = useState(() =>
-    typeof initialMapPreferences.showState === "boolean"
-      ? initialMapPreferences.showState
-      : true,
-  );
-  const [showProduction, setShowProduction] = useState(() =>
-    typeof initialMapPreferences.showProduction === "boolean"
-      ? initialMapPreferences.showProduction
-      : true,
-  );
-  const [showBlocked, setShowBlocked] = useState(() =>
-    typeof initialMapPreferences.showBlocked === "boolean"
-      ? initialMapPreferences.showBlocked
-      : false,
-  );
-  const [showSuggestions, setShowSuggestions] = useState(() =>
-    typeof initialMapPreferences.showSuggestions === "boolean"
-      ? initialMapPreferences.showSuggestions
-      : true,
-  );
-  const [localSuggestions, setLocalSuggestions] = useState<Suggestion[]>([]);
-  const [proposalLinks, setProposalLinks] = useState<Record<string, string>>({});
-  const [proposalResolutions, setProposalResolutions] = useState<
-    Record<string, "resolved">
-  >({});
-  const [placementError, setPlacementError] = useState("");
-  const [mapLocation, setMapLocation] = useState(() =>
-    typeof initialMapPreferences.location === "string"
-      ? initialMapPreferences.location
-      : "farm",
-  );
 
-  useEffect(() => {
-    fetch("/api/preferences", { cache: "no-store" })
-      .then((response) => response.json())
-      .then((preferences) => {
-        if (Array.isArray(preferences.suggestions))
-          setLocalSuggestions(preferences.suggestions);
-        if (
-          preferences.proposalLinks &&
-          typeof preferences.proposalLinks === "object" &&
-          !Array.isArray(preferences.proposalLinks)
-        )
-          setProposalLinks(preferences.proposalLinks);
-        if (
-          preferences.proposalResolutions &&
-          typeof preferences.proposalResolutions === "object" &&
-          !Array.isArray(preferences.proposalResolutions)
-        )
-          setProposalResolutions(preferences.proposalResolutions);
-      })
-      .catch(() => undefined);
-  }, []);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   useEffect(() => {
     const expectedProfileId = data?.profileId;
@@ -622,28 +558,7 @@ export default function Home() {
     return () => window.clearInterval(timer);
   }, [data?.profileId]);
 
-  useEffect(() => {
-    window.localStorage.setItem(
-      "stardew-tool-map-preferences",
-      JSON.stringify({
-        zoom,
-        location: mapLocation,
-        showGrid,
-        showState,
-        showProduction,
-        showBlocked,
-        showSuggestions,
-      }),
-    );
-  }, [
-    mapLocation,
-    showBlocked,
-    showGrid,
-    showProduction,
-    showState,
-    showSuggestions,
-    zoom,
-  ]);
+
 
   useEffect(() => {
     let loadingLatest = false;
@@ -781,13 +696,7 @@ export default function Home() {
       .catch(() => setPreviousDay(null));
   }, [data, gameCatalog, history, t]);
 
-  useEffect(() => {
-    if (!data || mapLocation === "farm") return;
-    if (!data.interiors.some((interior) => interior.id === mapLocation)) {
-      const frame = window.requestAnimationFrame(() => setMapLocation("farm"));
-      return () => window.cancelAnimationFrame(frame);
-    }
-  }, [data, mapLocation]);
+
 
   useEffect(() => {
     if (!data?.dailyBrief) return;
@@ -801,259 +710,31 @@ export default function Home() {
     }
   }, [data]);
 
-  const persist = (next: Suggestion[], remember = true) => {
-    if (remember) setProposalUndo(localSuggestions);
-    setLocalSuggestions(next);
-    fetch("/api/preferences", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ suggestions: next }),
-    }).catch(() => undefined);
-  };
 
-  const persistProposalLinks = (next: Record<string, string>) => {
-    setProposalLinks(next);
-    fetch("/api/preferences", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ proposalLinks: next }),
-    }).catch(() => undefined);
-  };
 
-  const persistProposalResolutions = (next: Record<string, "resolved">) => {
-    setProposalResolutions(next);
-    fetch("/api/preferences", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ proposalResolutions: next }),
-    }).catch(() => undefined);
-  };
 
-  const mapData = useMemo(() => {
-    if (!data || !live.active || !live.farmMap) return data;
-    const savedTerrain = new Map(
-      data.terrain.map((feature) => [tileKey(feature.x, feature.y), feature]),
-    );
-    const terrain = live.farmMap.terrain.map((feature) => {
-      const saved = savedTerrain.get(tileKey(feature.x, feature.y));
-      if (!saved)
-        return {
-          x: feature.x,
-          y: feature.y,
-          kind: feature.kind,
-          watered: feature.watered,
-        } as Terrain;
-      if (feature.kind === "HoeDirt" && !feature.hasCrop) {
-        const soil = { ...saved };
-        delete soil.crop;
-        delete soil.phase;
-        delete soil.cropRow;
-        return { ...soil, watered: feature.watered };
-      }
-      return { ...saved, watered: feature.watered };
-    });
-    return {
-      ...data,
-      terrain,
-      objects: live.farmMap.objects,
-      buildings: live.farmMap.buildings,
-    };
-  }, [data, live.active, live.farmMap]);
 
-  const proposalStates = useMemo(
-    () =>
-      mapData
-        ? reconcileProposals(
-            [...mapData.suggestions, ...localSuggestions],
-            mapData.buildings,
-            proposalLinks,
-            proposalResolutions,
-          )
-        : [],
-    [localSuggestions, mapData, proposalLinks, proposalResolutions],
-  );
 
-  const centerOnFarmhouse = useCallback(
-    (behavior: ScrollBehavior = "auto") => {
-      const viewport = mapViewportRef.current;
-      const farmhouse = mapData?.buildings.find(
-        (building) => buildingType(building) === "farmhouse",
-      );
-      if (!viewport || !farmhouse) return;
-      const centerX = (farmhouse.x + farmhouse.width / 2) * TILE * zoom;
-      const centerY = (farmhouse.y + farmhouse.height / 2) * TILE * zoom;
-      viewport.scrollTo({
-        left: Math.max(0, centerX - viewport.clientWidth / 2),
-        top: Math.max(0, centerY - viewport.clientHeight / 2),
-        behavior,
-      });
-    },
-    [mapData, zoom],
-  );
 
-  useEffect(() => {
-    if (activeView !== "map" || mapLocation !== "farm") return;
-    if (hasCenteredFarmRef.current) return;
-    if (
-      !mapData ||
-      !mapViewportRef.current ||
-      !mapData.buildings.some(
-        (building) => buildingType(building) === "farmhouse",
-      )
-    )
-      return;
-    hasCenteredFarmRef.current = true;
-    const frame = window.requestAnimationFrame(() => centerOnFarmhouse("auto"));
-    return () => window.cancelAnimationFrame(frame);
-  }, [activeView, centerOnFarmhouse, mapData, mapLocation]);
 
-  const validatePlacement = (point: Tile, width: number, height: number) => {
-    if (!mapData) return t("map.error.unavailable");
-    const cells = Array.from({ length: width * height }, (_, index) => ({
-      x: point.x + (index % width),
-      y: point.y + Math.floor(index / width),
-    }));
-    if (
-      cells.some(
-        (cell) =>
-          cell.x < 0 ||
-          cell.y < 0 ||
-          cell.x >= mapData.map.width ||
-          cell.y >= mapData.map.height,
-      )
-    )
-      return t("map.error.outsideFarm");
-    if (
-      cells.some((cell) =>
-        mapData.map.blocked.some(([x, y]) => x === cell.x && y === cell.y),
-      )
-    )
-      return t("map.error.nonBuildable");
-    if (
-      cells.some((cell) =>
-        mapData.buildings.some(
-          (building) =>
-            cell.x >= building.x &&
-            cell.x < building.x + building.width &&
-            cell.y >= building.y &&
-            cell.y < building.y + building.height,
-        ),
-      )
-    )
-      return t("map.error.existingBuilding");
-    if (
-      cells.some((cell) =>
-        mapData.objects.some(
-          (object) => {
-            if (object.x !== cell.x || object.y !== cell.y) return false;
-            if (object.kind === "Litter" || object.name === "Artifact Spot")
-              return false;
-            return !mapData.terrain.some(
-              (feature) =>
-                feature.x === object.x &&
-                feature.y === object.y &&
-                ["Tree", "FruitTree"].includes(feature.kind),
-            );
-          },
-        ),
-      )
-    )
-      return t("map.error.placedObject");
-    if (
-      cells.some((cell) =>
-        proposalStates.some(
-          (proposal) =>
-            proposal.status === "pending" &&
-            cell.x >= proposal.x &&
-            cell.x < proposal.x + proposal.width &&
-            cell.y >= proposal.y &&
-            cell.y < proposal.y + proposal.height,
-        ),
-      )
-    )
-      return t("map.error.pendingProposal");
-    return "";
-  };
+
+
+
+
+
+
+
+
 
   const draw = useFarmCanvas({ canvasRef, base, hover, mapData, localSuggestions, movingProposalId, proposalEditMode, proposalStates, showBlocked, showGrid, showProduction, showState, showSuggestions, sprites, tool, activeView, mapLocation });
 
-  const pointFromEvent = (event: React.MouseEvent<HTMLCanvasElement>) => {
-    const rect = event.currentTarget.getBoundingClientRect();
-    return {
-      x: Math.floor(((event.clientX - rect.left) / rect.width) * 80),
-      y: Math.floor(((event.clientY - rect.top) / rect.height) * 65),
-    };
-  };
 
-  const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
-    setProposalMenu(null);
-    const point = pointFromEvent(event);
-    setSelected(point);
-    if (movingProposalId) {
-      const moving = localSuggestions.find((item) => item.id === movingProposalId);
-      if (!moving) return setMovingProposalId(null);
-      const invalid = validatePlacement(point, moving.width, moving.height);
-      if (invalid) return setPlacementError(invalid);
-      persist(localSuggestions.map((item) =>
-        item.id === movingProposalId ? { ...item, x: point.x, y: point.y } : item,
-      ));
-      setMovingProposalId(null);
-      setPlacementError("");
-      return;
-    }
-    if (proposalEditMode && tool !== "inspect") {
-      const active = tools.find((item) => item.id === tool)!;
-      const invalid = validatePlacement(point, active.width, active.height);
-      if (invalid) {
-        setPlacementError(invalid);
-        return;
-      }
-      setPlacementError("");
-      persist([
-        ...localSuggestions,
-        {
-          id: `${tool}-${Date.now()}`,
-          kind: tool,
-          name: `Proposed ${active.label}`,
-          x: point.x,
-          y: point.y,
-          width: active.width,
-          height: active.height,
-          color: "#ffcf5c",
-        },
-      ]);
-      setTool("inspect");
-    }
-  };
 
-  const openProposalMenu = (event: React.MouseEvent<HTMLCanvasElement>) => {
-    event.preventDefault();
-    const point = pointFromEvent(event);
-    const proposal = [...localSuggestions].reverse().find(
-      (item) =>
-        point.x >= item.x &&
-        point.x < item.x + item.width &&
-        point.y >= item.y &&
-        point.y < item.y + item.height,
-    );
-    if (!proposal) {
-      setProposalMenu(null);
-      return;
-    }
-    setProposalMenu({
-      id: proposal.id,
-      name: proposal.name.replace(/^(Proposed|Future|Optional) /, ""),
-      x: event.clientX,
-      y: event.clientY,
-    });
-  };
 
-  useEffect(() => {
-    if (!proposalMenu) return;
-    const close = () => setProposalMenu(null);
-    document.addEventListener("click", close);
-    return () => document.removeEventListener("click", close);
-  }, [proposalMenu]);
+
+
+
+
 
   const beginPanelResize = (
     side: "left" | "right",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node scripts/dev-local.mjs",
     "build": "npm run verify:changelog && vinext build && node scripts/prepare-built-public.mjs",
     "start": "vinext start",
-    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs tests/fishing-snapshot.test.mjs tests/mod-consumers.test.mjs tests/mod-production-extractor.test.mjs tests/dashboard-modules.test.mjs tests/dashboard-navigation.test.mjs",
+    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs tests/fishing-snapshot.test.mjs tests/mod-consumers.test.mjs tests/mod-production-extractor.test.mjs tests/dashboard-modules.test.mjs tests/dashboard-navigation.test.mjs tests/farm-editor-interaction.test.mjs",
     "verify:changelog": "node scripts/verify-changelog.mjs",
     "verify:localization": "node scripts/verify-localization-ui.mjs",
     "verify:public": "node scripts/verify-public-safety.mjs",

--- a/tests/dashboard-modules.test.mjs
+++ b/tests/dashboard-modules.test.mjs
@@ -36,6 +36,20 @@ test("construction reconciliation deduplicates proposals and honors manual match
   assert.equal(reconcileProposals([proposal], [{ ...proposal }])[0].status, "completed");
 });
 
+test("farm placement rejects boundaries and occupied cells before accepting an empty footprint", async () => {
+  const { validateFarmPlacement } = await pureModule("farm-model");
+  const t = (key) => key;
+  const farm = { map: { width: 10, height: 10, blocked: [[2, 2]] }, buildings: [{ x: 4, y: 4, width: 2, height: 2 }], objects: [{ id: "(BC)Example", name: "Example", x: 7, y: 7 }], terrain: [] };
+  const check = (point, proposals = []) => validateFarmPlacement(farm, proposals, point, 1, 1, t);
+  assert.equal(validateFarmPlacement(null, [], { x: 0, y: 0 }, 1, 1, t), "map.error.unavailable");
+  assert.equal(check({ x: -1, y: 0 }), "map.error.outsideFarm");
+  assert.equal(check({ x: 2, y: 2 }), "map.error.nonBuildable");
+  assert.equal(check({ x: 5, y: 5 }), "map.error.existingBuilding");
+  assert.equal(check({ x: 7, y: 7 }), "map.error.placedObject");
+  assert.equal(check({ x: 8, y: 8 }, [{ x: 8, y: 8, width: 1, height: 1, status: "pending" }]), "map.error.pendingProposal");
+  assert.equal(check({ x: 0, y: 0 }), "");
+});
+
 test("dashboard modules have no dependency cycles or imports back into the page", async () => {
   const directory = new URL("../app/dashboard/", import.meta.url);
   const graph = new Map();

--- a/tests/farm-editor-interaction.test.mjs
+++ b/tests/farm-editor-interaction.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+test("left and right clicks open the same proposal menu and an empty tile dismisses it", async () => {
+  const writes = [];
+  const proposal = { id: "synthetic", name: "Proposed Coop", x: 2, y: 3, width: 6, height: 3 };
+  globalThis.__farmEditorInteraction = {
+    useState: (initial) => {
+      const value = typeof initial === "function" ? initial() : initial;
+      return [Array.isArray(value) ? [proposal] : value, (next) => writes.push(next)];
+    },
+    useRef: (current) => ({ current }), useEffect: () => {},
+    useMemo: (factory) => factory(), useCallback: (callback) => callback,
+    useI18n: () => ({ t: (key) => key }),
+    reconcileProposals: () => [], buildingType: () => "", validateFarmPlacement: () => "",
+    tileKey: (x, y) => `${x}:${y}`, TILE: 16, tools: [],
+  };
+  try {
+    const source = await readFile(new URL("../app/dashboard/use-farm-editor.ts", import.meta.url), "utf8");
+    const { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 } });
+    const code = outputText.replace(/import\s*\{([^}]+)\}\s*from "[^"]+";/g, "const {$1} = globalThis.__farmEditorInteraction;");
+    const { useFarmEditor } = await import(`data:text/javascript;base64,${Buffer.from(code).toString("base64")}`);
+    const editor = useFarmEditor(null, { active: false }, "map");
+    const event = (x, y) => ({
+      clientX: x, clientY: y,
+      currentTarget: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 80, height: 65 }) },
+      preventDefault() { this.prevented = true; },
+      stopPropagation() { this.stopped = true; },
+    });
+    const left = event(3, 4);
+    editor.handleClick(left);
+    assert.deepEqual(writes.at(-1), { id: "synthetic", name: "Coop", x: 3, y: 4 });
+    assert.equal(left.stopped, true, "the opening click must not reach the outside-click closer");
+    editor.openProposalMenu(event(3, 4));
+    assert.deepEqual(writes.at(-1), { id: "synthetic", name: "Coop", x: 3, y: 4 });
+    editor.handleClick(event(0, 0));
+    assert.equal(writes.at(-1), null);
+  } finally {
+    delete globalThis.__farmEditorInteraction;
+  }
+});


### PR DESCRIPTION
## Changes
Farm proposals now expose Move, Delete and Mark plan done through both left and right clicks; resolved proposals offer Reopen plan. Clicks continue placing/moving when those tools are active, and opening a menu does not immediately trigger its outside-click closer.

Move farm editor preferences, selection, proposal persistence, movement, undo state and centering into useFarmEditor. Extract placement validation into the pure farm model. The page retains the visible layout and application-owned persistence keys are unchanged. Part of #16.

## Validation
Public safety, lint, TypeScript and build passed. npm test: 151 passed, one opt-in local test skipped. Behavioral tests cover left/right menu opening, empty-tile dismissal, event propagation and placement restrictions. Existing navigation and dependency-cycle checks pass.

## Manual verification
Left-click your proposal in Map and choose Move, Delete or Mark plan done. Click a new location to move; try undo and invalid destinations. Check right-click parity and reopening a resolved proposal. Maintainer approved the desktop behavior; squash merge and branch cleanup authorized.

