### PR TITLE
fix(planning): reconcile machines and inventory by qualified identity

### DIFF
--- a/app/dashboard/identity.ts
+++ b/app/dashboard/identity.ts
@@ -24,3 +24,8 @@ export const normalizeObjectId = (id?: string | null) => qualifyItemId(id, "obje
 
 export const inventoryItemId = (item: Pick<ItemArtwork, "id" | "spriteKind">) =>
   qualifyItemId(item.id, item.spriteKind || "object");
+
+export function sameInventoryIdentity(left: Pick<ItemArtwork, "id" | "spriteKind">, right: Pick<ItemArtwork, "id" | "spriteKind">) {
+  const id = inventoryItemId(left);
+  return Boolean(id) && id === inventoryItemId(right);
+}

--- a/app/dashboard/machine-selectors.ts
+++ b/app/dashboard/machine-selectors.ts
@@ -1,0 +1,61 @@
+import type { LiveMachine, MachinePlan, MachineOutput } from "./snapshot-types";
+import { qualifyItemId } from "./identity";
+
+export function summarizeLiveMachines(
+  items: LiveMachine[],
+  savedMachines: MachinePlan[] = [],
+): MachinePlan[] {
+  const grouped = new Map<string, MachinePlan>();
+  const addOutput = (list: MachineOutput[] | undefined, name: string) => {
+    const outputs = list || [];
+    const existing = outputs.find((item) => item.name === name);
+    if (existing) existing.count += 1;
+    else outputs.push({ name, count: 1 });
+    return outputs;
+  };
+  for (const item of items) {
+    const id = item.id ? qualifyItemId(item.id, "craftable") : undefined;
+    // Older payloads without an ID remain separate from identified machines.
+    const key = id ? `id:${id}` : `legacy:${item.name}`;
+    const saved = id ? savedMachines.find((machine) => machine.id && qualifyItemId(machine.id, "craftable") === id) : undefined;
+    const machine = grouped.get(key) || {
+      id,
+      displayName: saved?.displayName,
+      name: item.name,
+      count: 0,
+      ready: 0,
+      working: 0,
+      idle: 0,
+      readyOutputs: [],
+      workingOutputs: [],
+      inputs: [],
+      locations: [],
+      nextReadyMinutes: null,
+    };
+    machine.count += 1;
+    machine.ready += item.ready ? 1 : 0;
+    machine.working += item.processing && !item.ready ? 1 : 0;
+    machine.idle =
+      (machine.idle || 0) + (!item.ready && !item.processing ? 1 : 0);
+    if (!machine.locations!.includes(item.location))
+      machine.locations!.push(item.location);
+    if (item.output && item.ready)
+      machine.readyOutputs = addOutput(machine.readyOutputs, item.output);
+    else if (item.output && item.processing)
+      machine.workingOutputs = addOutput(machine.workingOutputs, item.output);
+    if (item.input && item.processing)
+      machine.inputs = addOutput(machine.inputs, item.input);
+    if (item.processing && (item.minutesUntilReady || 0) > 0)
+      machine.nextReadyMinutes =
+        machine.nextReadyMinutes === null
+          ? item.minutesUntilReady!
+          : Math.min(machine.nextReadyMinutes!, item.minutesUntilReady!);
+    grouped.set(key, machine);
+  }
+  return [...grouped.values()].sort(
+    (a, b) =>
+      b.ready - a.ready ||
+      (b.idle || 0) - (a.idle || 0) ||
+      a.name.localeCompare(b.name),
+  );
+}

--- a/app/dashboard/planning-view.tsx
+++ b/app/dashboard/planning-view.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { summarizeLiveMachines } from "./machine-selectors";
+
 import { useI18n } from "../i18n";
 import { useState } from "react";
 import { useEffect } from "react";
@@ -7,8 +9,8 @@ import { ProductionCalculator } from "../planning/production-calculator";
 import { type Snapshot, type LiveState, type BuildingPlan, type StorageInventoryItem, type StorageSourceDetail, type BundleRequirement, type FriendshipPlan } from "./snapshot-types";
 import { type FarmHistory, type PlanningSection, type PersonalGoal, type StrategicGoalTarget } from "./ui-types";
 import { resolveGameDisplayName, isVanillaFriend } from "./game-names";
-import { inventoryItemId, normalizeObjectId } from "./identity";
-import { liveStorageSource, readyBundleDeliveries, summarizeLiveMachines } from "./selectors";
+import { inventoryItemId, normalizeObjectId, sameInventoryIdentity } from "./identity";
+import { liveStorageSource, readyBundleDeliveries } from "./selectors";
 import { localizedStorageSource, formatHarvestDate, buildingPlanText, communityRoomName, communityBundleName, formatLiveTime, formatBundleRequirement, communityRoomReward, cropPlanNote, buildingCategoryName, buildingProjectTypeName, routeLocationName, formatMachineDuration } from "./formatting";
 import { readableStorageSource, readableStorageLocation, StorageLocationPreview } from "./storage";
 import { ItemMentionArtwork, CommunityRoomArtwork, ModdedItemArtwork, SheetArtwork, AnimalArtwork, StorageArtwork, StorageContainerArtwork, GoalRequirements, NpcArtwork, GiftGroup } from "./artwork";
@@ -168,8 +170,7 @@ export function PlanningView({
           ...live.inventory.map((item) => {
             const savedItem = savedBackpackInventory.find(
               (candidate) =>
-                inventoryItemId(candidate) === inventoryItemId(item) &&
-                candidate.name === item.name,
+                sameInventoryIdentity(candidate, item),
             );
             return {
               ...savedItem,
@@ -188,8 +189,7 @@ export function PlanningView({
                 const source = liveStorageSource(item);
                 const savedItem = savedChestInventory.find(
                   (candidate) =>
-                    inventoryItemId(candidate) === inventoryItemId(item) &&
-                    candidate.name === item.name,
+                    sameInventoryIdentity(candidate, item),
                 );
                 const savedDetail = savedItem?.sourceDetails?.find(
                   (detail) => detail.source === source,
@@ -1511,18 +1511,19 @@ export function PlanningView({
                   const duration = formatMachineDuration(
                     machine.nextReadyMinutes,
                   );
-                  const isCrabPot = machine.name === "Crab Pot";
+                  const isObjectMachine = machine.id?.startsWith("(O)");
+                  const isCrabPot = machine.id === "(O)710";
                   return (
                     <details
                       className={
                         machine.ready ? "has-ready" : idle ? "has-idle" : ""
                       }
-                      key={machine.name}
+                      key={machine.id || machine.name}
                     >
                       <summary>
                         <SheetArtwork
                           id={machine.id}
-                          kind={isCrabPot ? "object" : "craftable"}
+                          kind={isObjectMachine ? "object" : "craftable"}
                           label={machine.displayName || machine.name}
                         />
                         <span className="machine-heading">
@@ -1592,12 +1593,12 @@ export function PlanningView({
           <section className="production-advice">
             <p className="eyebrow">{t("web.planning.nextBottleneck")}</p>
             <h2>
-              {machines.some((machine) => machine.name === "Keg")
+              {machines.some((machine) => machine.id === "(BC)12")
                 ? t("web.production.fillKegsFirst")
                 : t("web.production.preserveJarsFirst")}
             </h2>
             <p>
-              {machines.some((machine) => machine.name === "Keg")
+              {machines.some((machine) => machine.id === "(BC)12")
                 ? t("web.production.kegAdvice")
                 : machineTotals.ready
                   ? t("web.production.collectBeforeBatch", { count: machineTotals.ready })

--- a/app/dashboard/selectors.ts
+++ b/app/dashboard/selectors.ts
@@ -1,5 +1,5 @@
 import packageMetadata from "../../package.json";
-import { type LiveStorageItem, type Snapshot, type LiveState, type LiveQuest, type DailyQuest, type FarmObject, type CommunityRoom, type LiveMachine, type MachinePlan, type MachineOutput } from "./snapshot-types";
+import { type LiveStorageItem, type Snapshot, type LiveState, type LiveQuest, type DailyQuest, type FarmObject, type CommunityRoom, type LiveMachine } from "./snapshot-types";
 import { type SessionSummary, type Translate, type FeedbackKind, type DesktopDiagnostics, type ActiveView } from "./ui-types";
 import { normalizeObjectId, inventoryItemId } from "./identity";
 
@@ -247,61 +247,4 @@ export function summarizeReadyLiveMachines(items: LiveMachine[]) {
     grouped.set(label, (grouped.get(label) || 0) + 1);
   }
   return [...grouped].map(([label, count]) => `${count}× ${label}`).join(" · ");
-}
-
-export function summarizeLiveMachines(
-  items: LiveMachine[],
-  savedMachines: MachinePlan[] = [],
-): MachinePlan[] {
-  const grouped = new Map<string, MachinePlan>();
-  const addOutput = (list: MachineOutput[] | undefined, name: string) => {
-    const outputs = list || [];
-    const existing = outputs.find((item) => item.name === name);
-    if (existing) existing.count += 1;
-    else outputs.push({ name, count: 1 });
-    return outputs;
-  };
-  for (const item of items) {
-    const savedId = savedMachines.find(
-      (machine) => machine.name === item.name,
-    )?.id;
-    const machine = grouped.get(item.name) || {
-      id: item.id || savedId,
-      name: item.name,
-      count: 0,
-      ready: 0,
-      working: 0,
-      idle: 0,
-      readyOutputs: [],
-      workingOutputs: [],
-      inputs: [],
-      locations: [],
-      nextReadyMinutes: null,
-    };
-    machine.count += 1;
-    machine.ready += item.ready ? 1 : 0;
-    machine.working += item.processing && !item.ready ? 1 : 0;
-    machine.idle =
-      (machine.idle || 0) + (!item.ready && !item.processing ? 1 : 0);
-    if (!machine.locations!.includes(item.location))
-      machine.locations!.push(item.location);
-    if (item.output && item.ready)
-      machine.readyOutputs = addOutput(machine.readyOutputs, item.output);
-    else if (item.output && item.processing)
-      machine.workingOutputs = addOutput(machine.workingOutputs, item.output);
-    if (item.input && item.processing)
-      machine.inputs = addOutput(machine.inputs, item.input);
-    if (item.processing && (item.minutesUntilReady || 0) > 0)
-      machine.nextReadyMinutes =
-        machine.nextReadyMinutes === null
-          ? item.minutesUntilReady!
-          : Math.min(machine.nextReadyMinutes!, item.minutesUntilReady!);
-    grouped.set(item.name, machine);
-  }
-  return [...grouped.values()].sort(
-    (a, b) =>
-      b.ready - a.ready ||
-      (b.idle || 0) - (a.idle || 0) ||
-      a.name.localeCompare(b.name),
-  );
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "node scripts/dev-local.mjs",
     "build": "npm run verify:changelog && vinext build && node scripts/prepare-built-public.mjs",
     "start": "vinext start",
-    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs tests/fishing-snapshot.test.mjs tests/mod-consumers.test.mjs tests/mod-production-extractor.test.mjs tests/dashboard-modules.test.mjs tests/dashboard-navigation.test.mjs",
+    "test": "npm run verify:localization && npm run build && node --test tests/rendered-html.test.mjs tests/localization.test.mjs tests/changelog.test.mjs tests/release-notes.test.mjs tests/mod-compatibility.test.mjs tests/route-planner.test.mjs tests/production-engine.test.mjs tests/forestry-engine.test.mjs tests/machine-engine.test.mjs tests/animal-engine.test.mjs tests/pond-engine.test.mjs tests/portfolio-engine.test.mjs tests/local-package.test.mjs tests/fishing-snapshot.test.mjs tests/mod-consumers.test.mjs tests/mod-production-extractor.test.mjs tests/dashboard-modules.test.mjs tests/dashboard-navigation.test.mjs tests/machine-identity.test.mjs",
     "verify:changelog": "node scripts/verify-changelog.mjs",
     "verify:localization": "node scripts/verify-localization-ui.mjs",
     "verify:public": "node scripts/verify-public-safety.mjs",

--- a/scripts/generate_snapshot.py
+++ b/scripts/generate_snapshot.py
@@ -1286,8 +1286,10 @@ def planning_brief(root: ET.Element, player: ET.Element, locations: ET.Element, 
     for obj in objects:
         if not is_production_machine(obj):
             continue
-        entry = machine_counts.setdefault(obj["name"], {
-            "id": obj.get("id", ""), "name": obj["name"], "count": 0, "ready": 0, "working": 0, "idle": 0,
+        machine_id = qualified_item_id(obj.get("id", ""), "craftable" if obj.get("big") else "object")
+        machine_key = machine_id or f"legacy:{obj['name']}"
+        entry = machine_counts.setdefault(machine_key, {
+            "id": machine_id, "name": obj["name"], "count": 0, "ready": 0, "working": 0, "idle": 0,
             "readyOutputs": {}, "workingOutputs": {}, "inputs": {}, "locations": set(),
             "nextReadyMinutes": None,
         })

--- a/tests/machine-identity.test.mjs
+++ b/tests/machine-identity.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import ts from "typescript";
+
+async function moduleUrl(name, imports = {}) {
+  const source = await readFile(new URL(`../app/dashboard/${name}.ts`, import.meta.url), "utf8");
+  let { outputText } = ts.transpileModule(source, { compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 } });
+  for (const [path, url] of Object.entries(imports)) outputText = outputText.replace(JSON.stringify(path), JSON.stringify(url));
+  return `data:text/javascript;base64,${Buffer.from(outputText).toString("base64")}`;
+}
+
+test("LIVE machines group by qualified identity across labels and never alias namespaces", async () => {
+  const identity = await moduleUrl("identity");
+  const { summarizeLiveMachines } = await import(await moduleUrl("machine-selectors", { "./identity": identity }));
+  const live = (id, name, ready = false) => ({ id, name, ready, processing: false, location: "Farm" });
+  const result = summarizeLiveMachines([
+    live("(BC)12", "Keg", true), live("(BC)12", "Barril"),
+    live("(BC)Example", "Keg"), live("(O)12", "Keg"), live(undefined, "Keg"),
+  ], [{ id: "12", name: "Keg", displayName: "Barril" }]);
+  assert.equal(result.length, 4);
+  const keg = result.find((machine) => machine.id === "(BC)12");
+  assert.equal(keg.count, 2);
+  assert.equal(keg.ready, 1);
+  assert.equal(keg.idle, 1);
+  assert.equal(keg.displayName, "Barril");
+  assert.equal(result.find((machine) => !machine.id).count, 1);
+});
+
+test("inventory artwork reconciliation tolerates translated names but requires an exact identity", async () => {
+  const { sameInventoryIdentity } = await import(await moduleUrl("identity"));
+  assert.equal(sameInventoryIdentity({ id: "(O)12", name: "English" }, { id: "12", name: "Español", spriteKind: "object" }), true);
+  assert.equal(sameInventoryIdentity({ id: "(BC)12" }, { id: "(O)12" }), false);
+  assert.equal(sameInventoryIdentity({ id: "" }, { id: "" }), false);
+});
+
+test("save machine grouping preserves namespace and mod identifiers", () => {
+  const result = spawnSync(process.env.PYTHON || (process.platform === "win32" ? "python" : "python3"), [fileURLToPath(new URL("./machine_snapshot_identity_test.py", import.meta.url))], { encoding: "utf8", windowsHide: true });
+  assert.equal(result.status, 0, result.error?.message || result.stderr || result.stdout);
+});

--- a/tests/machine_snapshot_identity_test.py
+++ b/tests/machine_snapshot_identity_test.py
@@ -1,0 +1,22 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import xml.etree.ElementTree as ET
+
+sys.modules["PIL"] = types.SimpleNamespace(Image=None)
+spec = importlib.util.spec_from_file_location("snapshot", Path(__file__).parents[1] / "scripts/generate_snapshot.py")
+snapshot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(snapshot)
+root = ET.fromstring("<SaveGame><player/><locations><GameLocation><name>Farm</name></GameLocation></locations></SaveGame>")
+objects = [
+    {"id": "12", "name": "Keg", "big": True},
+    {"id": "Example.Keg", "name": "Keg", "big": True},
+    {"id": "12", "name": "Crab Pot", "big": False},
+    {"id": "(BC)12", "name": "Keg", "big": True},
+]
+plan = snapshot.planning_brief(root, root.find("player"), root.find("locations"), "spring", 1, 0, objects, {})
+machines = {item["id"]: item for item in plan["machines"]}
+assert set(machines) == {"(BC)12", "(BC)Example.Keg", "(O)12"}
+assert machines["(BC)12"]["count"] == 2
+assert machines["(O)12"]["count"] == 1

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -441,11 +441,11 @@ test("production machine artwork keeps the complete two-tile sprite", async () =
   ]);
   assert.match(
     page,
-    /kind=\{isCrabPot \? "object" : "craftable"\}[\s\S]*?label=\{machine\.displayName \|\| machine\.name\}/,
+    /kind=\{isObjectMachine \? "object" : "craftable"\}[\s\S]*?label=\{machine\.displayName \|\| machine\.name\}/,
   );
   assert.doesNotMatch(
     page,
-    /<SheetArtwork\s+id=\{machine\.id\}\s+kind=\{isCrabPot \? "object" : "craftable"\}\s+label=\{machine\.displayName \|\| machine\.name\}\s+fit\s*\/>/,
+    /<SheetArtwork\s+id=\{machine\.id\}\s+kind=\{isObjectMachine \? "object" : "craftable"\}\s+label=\{machine\.displayName \|\| machine\.name\}\s+fit\s*\/>/,
   );
   assert.match(styles, /\.sheet-artwork\.object,\s*\.sheet-artwork\.object2/);
   assert.match(styles, /\.machine-heading > span \{/);
@@ -1608,7 +1608,7 @@ test("Production counts functional machines, interiors, live storage, and action
   assert.match(generator, /"readyOutputs"/);
   assert.match(page, /t\("web\.planning\.whatToCollectAndRefill"\)/);
   assert.match(page, /summarizeLiveMachines/);
-  assert.match(page, /kind=\{isCrabPot \? "object" : "craftable"\}/);
+  assert.match(page, /kind=\{isObjectMachine \? "object" : "craftable"\}/);
   assert.match(page, /t\("web\.planning\.currentMachinesAndCrabPots"\)/);
   assert.match(page, /legacyCraftableSpriteIndex/);
   assert.match(page, /\{idle\}\{t\("web\.planning\.idle"\)\}/);

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -1619,7 +1619,8 @@ test("Production counts functional machines, interiors, live storage, and action
   assert.match(bridge, /machines = cachedMachines/);
   assert.match(bridge, /id = pair\.Value\.QualifiedItemId/);
   assert.match(bridge, /"Crab Pot"/);
-  assert.match(generator, /"id": obj\.get\("id", ""\)/);
+  assert.match(generator, /"id": machine_id/);
+  assert.match(generator, /machine_id = qualified_item_id/);
 });
 
 test("Grandpa forecast separates projected milestones from points confirmed today", async () => {


### PR DESCRIPTION
## Changes
Machines with the same display name could be combined even when their game identifiers differed. Group save and LIVE machines by qualified identity, keep unidentified legacy records separate, and recover saved display metadata by ID. Match inventory metadata without requiring English/localized names to agree. Use qualified IDs for keg advice and crab-pot behavior; derive machine artwork namespace from the ID.

The affected vanilla IDs were checked against the legitimate local game catalog. No extracted data is committed. Part of #16; other legacy rules and output labels are outside this small delivery.

## Validation
Public safety, lint, TypeScript and build passed. npm test: 149 passed, one local opt-in test skipped. New synthetic tests cover equal names with different IDs, equal numeric suffixes in different namespaces, translated names, unknown identities and save-side machine grouping.

## Manual verification
Check machine counts and artwork with the game closed and LIVE active; switch language; inspect storage item artwork. Independent of #87, both target development. Awaiting maintainer approval before squash merge and branch deletion.
