### PR TITLE
Prepare v1.12.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
           STARDEW_PATH: ${{ github.workspace }}\.stardew-reference-assemblies
         run: npm run desktop:installer
 
+      - name: Inspect packaged application before publishing
+        run: node --input-type=module -e "import { inspectLocalPackage } from './scripts/local-package.mjs'; inspectLocalPackage();"
+
       - name: Create SHA-256 checksums
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 This file records the user-facing changes in each public release of Maglucen Stardew Valley Companion.
 
+## 1.12.0 — 2026-09-05
+
+### New
+
+- Added persistent high contrast, independent text sizing from 75% to 200%, and a prominent, replayable six-step dashboard guide.
+- Added keyboard map coordinate controls for inspecting tiles and placing or moving companion proposals, with accessible dialogs and named storage-location actions.
+- Added route profiles and contextual delivery and fishing stops that account for access, unlocked transport, festivals, and shop hours.
+- Added support for verified local Content Patcher crop changes and local modded fishing data, with contextual compatibility information when changes cannot be verified.
+
+### Improved
+
+- Proposal actions are available through both left and right clicks, with a shared menu for movement, completion, reopening, and deletion.
+- Dashboard navigation, session tracking, map rendering, and planning views now have separate modules and regression coverage.
+- Machine states and economy charts use symbols, solid or dashed lines, and striped bars alongside color.
+
+### Fixed
+
+- Farm selection now isolates history and LIVE state, and the development loader respects the saved display.
+- Inventory, machines, planning materials, and tool identities preserve qualified game identifiers and product variants.
+- Map inspection distinguishes empty tilled soil from planted crops and seeds, including updated LIVE crop identities through bridge 5.1.2.
+- Currency and language indicators use artwork extracted from the local game installation without distributing game assets.
+
 ## 1.11.1 — 2026-09-04
 
 ### Improved

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maglucen-stardew-valley-companion",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maglucen-stardew-valley-companion",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "hasInstallScript": true,
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maglucen-stardew-valley-companion",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Maglucen's local, save-aware companion for Stardew Valley.",
   "author": "maglucen",
   "main": "desktop/main.mjs",


### PR DESCRIPTION
Prepare version 1.12.0 and its release notes for the approved dashboard, route, mod-compatibility, and accessibility changes on development. The release workflow now inspects the packaged application before publishing assets.

Validation: local release-quality checks (public-source safety, runtime audit, lint, build and 172 passing tests with one optional skip). The local Windows installer is also being built and inspected. Publication remains tied to the public main-branch tag and GitHub Actions provenance.
